### PR TITLE
Add Library Management and Scanning Feature

### DIFF
--- a/index.php
+++ b/index.php
@@ -830,6 +830,7 @@ form button:hover { background:#45a049; }
       </div>
       <button class="btn" id="reorder-btn" title="Toggle Reorder Mode">Reorder</button>
       <button class="btn" id="users-btn" title="Manage Users">👥 Users</button>
+      <button class="btn" id="libraries-btn" title="Manage Libraries">📚 Libraries</button>
       <button class="btn" id="logs-btn" title="View System Logs" onclick="window.open('view_logs.php', '_blank')">📜 Logs</button>
       <?php endif; ?>
       <button class="btn" id="activeonly-btn" title="Show Only Active Servers">Active Only</button>
@@ -924,6 +925,7 @@ form button:hover { background:#45a049; }
               </select>
             </div>
             <div class="form-group">
+              <label>&nbsp;</label>
               <button type="submit" class="btn primary">Add User</button>
             </div>
           </div>
@@ -934,6 +936,29 @@ form button:hover { background:#45a049; }
       <div class="users-list-container">
         <h3>Existing Users</h3>
         <div id="users-list"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Libraries Management Modal -->
+<div id="libraries-modal" class="modal">
+  <div class="modal-content">
+    <span class="modal-close" onclick="closeLibrariesModal()">&times;</span>
+    <div id="libraries-modal-body">
+      <h2 style="margin-bottom: 20px;">Manage Libraries</h2>
+
+      <div class="info-box" style="margin-bottom:20px; padding:15px; background:rgba(255,255,255,0.05); border-radius:6px;">
+        <label style="display:block; margin-bottom:10px;">Select Server:</label>
+        <select id="library-server-select" style="width:100%; max-width:300px; padding:10px; background:var(--bg); color:var(--text); border:1px solid var(--border); border-radius:4px;">
+           <option value="">-- Select a Server --</option>
+        </select>
+      </div>
+
+      <div id="libraries-list-container" style="min-height:200px;">
+         <div class="empty" id="libraries-loading" style="display:none;">Loading libraries...</div>
+         <div class="empty" id="libraries-empty">Select a server to view libraries.</div>
+         <div id="libraries-list" style="display:grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap:12px;"></div>
       </div>
     </div>
   </div>
@@ -2216,6 +2241,146 @@ document.getElementById('users-modal').addEventListener('click', function(e) {
         closeUsersModal();
     }
 });
+
+// Libraries Management
+if (IS_ADMIN) {
+    const libBtn = document.getElementById('libraries-btn');
+    if (libBtn) {
+        libBtn.addEventListener('click', function() {
+            openLibrariesModal();
+        });
+    }
+}
+
+function openLibrariesModal() {
+    const modal = document.getElementById('libraries-modal');
+    modal.classList.add('visible');
+
+    // Populate Server Select
+    const select = document.getElementById('library-server-select');
+    select.innerHTML = '<option value="">-- Select a Server --</option>';
+
+    SERVERS.forEach(server => {
+        const option = document.createElement('option');
+        option.value = server.name;
+        option.textContent = `${server.name} (${server.type})`;
+        select.appendChild(option);
+    });
+
+    // Reset View
+    document.getElementById('libraries-list').innerHTML = '';
+    document.getElementById('libraries-empty').style.display = 'block';
+
+    // Event Listener for Select
+    select.onchange = function() {
+        if (this.value) {
+            fetchLibraries(this.value);
+        } else {
+            document.getElementById('libraries-list').innerHTML = '';
+            document.getElementById('libraries-empty').style.display = 'block';
+        }
+    };
+}
+
+function closeLibrariesModal() {
+    document.getElementById('libraries-modal').classList.remove('visible');
+}
+
+// Close libraries modal when clicking outside
+document.getElementById('libraries-modal').addEventListener('click', function(e) {
+    if (e.target === this) {
+        closeLibrariesModal();
+    }
+});
+
+async function fetchLibraries(serverName) {
+    const list = document.getElementById('libraries-list');
+    const empty = document.getElementById('libraries-empty');
+    const loading = document.getElementById('libraries-loading');
+
+    list.innerHTML = '';
+    empty.style.display = 'none';
+    loading.style.display = 'block';
+
+    try {
+        const response = await fetch(`library_actions.php?action=list&server=${encodeURIComponent(serverName)}`);
+        const data = await response.json();
+
+        loading.style.display = 'none';
+
+        if (data.success) {
+            if (data.libraries.length === 0) {
+                empty.textContent = 'No libraries found.';
+                empty.style.display = 'block';
+                return;
+            }
+
+            // Render libraries
+            data.libraries.forEach(lib => {
+                const item = document.createElement('div');
+                item.className = 'user-item'; // Reuse existing style
+                item.style.background = 'rgba(0,0,0,0.3)';
+
+                item.innerHTML = `
+                    <div class="user-item-info">
+                        <div class="user-item-username">${esc(lib.name)}</div>
+                        <div class="user-item-meta">
+                            Type: ${esc(lib.type)}
+                        </div>
+                    </div>
+                    <div class="user-item-actions">
+                        <button class="btn primary" onclick="scanLibrary('${esc(serverName)}', '${esc(lib.id)}', this)">🔄 Scan</button>
+                    </div>
+                `;
+                list.appendChild(item);
+            });
+
+        } else {
+            empty.textContent = 'Error: ' + (data.error || 'Unknown error');
+            empty.style.display = 'block';
+        }
+    } catch (error) {
+        console.error('Error fetching libraries:', error);
+        loading.style.display = 'none';
+        empty.textContent = 'Failed to fetch libraries';
+        empty.style.display = 'block';
+    }
+}
+
+async function scanLibrary(serverName, libraryId, btn) {
+    if (btn) {
+        btn.disabled = true;
+        btn.textContent = '⏳ Starting...';
+    }
+
+    try {
+        const response = await fetch(`library_actions.php?action=scan&server=${encodeURIComponent(serverName)}&library_id=${encodeURIComponent(libraryId)}`);
+        const data = await response.json();
+
+        if (data.success) {
+            if (btn) btn.textContent = '✅ Started';
+            setTimeout(() => {
+                if (btn) {
+                    btn.disabled = false;
+                    btn.textContent = '🔄 Scan';
+                }
+            }, 3000);
+        } else {
+            alert('Error: ' + data.error);
+            if (btn) {
+                btn.disabled = false;
+                btn.textContent = '❌ Failed';
+            }
+        }
+    } catch (error) {
+        console.error('Error scanning library:', error);
+        alert('Failed to start scan');
+        if (btn) {
+            btn.disabled = false;
+            btn.textContent = '❌ Error';
+        }
+    }
+}
 </script>
 </body>
 </html>

--- a/library_actions.php
+++ b/library_actions.php
@@ -1,0 +1,205 @@
+<?php
+require_once 'auth.php';
+require_once 'encryption_helper.php';
+require_once 'logging.php';
+
+requireLogin();
+header('Content-Type: application/json');
+
+// Only admins should manage libraries
+if (!isAdmin()) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+$action = $_GET['action'] ?? '';
+$serverName = $_GET['server'] ?? '';
+$libraryId = $_GET['library_id'] ?? '';
+
+if (!$serverName || !$action) {
+    echo json_encode(['error' => 'Missing parameters']);
+    exit;
+}
+
+// Load server config
+$serversFile = 'servers.json';
+if (!file_exists($serversFile)) {
+    echo json_encode(['error' => 'No servers configured']);
+    exit;
+}
+
+$serversConfig = json_decode(file_get_contents($serversFile), true);
+$servers = $serversConfig['servers'] ?? [];
+$server = null;
+
+foreach ($servers as $s) {
+    if ($s['name'] === $serverName) {
+        $server = $s;
+        break;
+    }
+}
+
+if (!$server) {
+    echo json_encode(['error' => 'Server not found']);
+    exit;
+}
+
+// Helper for protocol
+function ensureProtocol($url) {
+    if (!preg_match('/^https?:\/\//', $url)) {
+        return 'http://' . $url;
+    }
+    return $url;
+}
+
+$baseUrl = ensureProtocol($server['url']);
+$type = $server['type'];
+
+// Decrypt credentials
+$token = '';
+if ($type === 'plex' && isset($server['token'])) {
+    $token = decrypt($server['token']);
+} elseif ($type === 'emby' && isset($server['apiKey'])) {
+    $token = decrypt($server['apiKey']);
+}
+
+// --- PLEX LOGIC ---
+if ($type === 'plex') {
+    if ($action === 'list') {
+        $url = rtrim($baseUrl, '/') . '/library/sections';
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            "X-Plex-Token: $token",
+            "Accept: application/json"
+        ]);
+
+        $res = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode !== 200) {
+            echo json_encode(['error' => "Plex API Error: HTTP $httpCode"]);
+            exit;
+        }
+
+        $data = json_decode($res, true);
+        $libraries = [];
+
+        if (isset($data['MediaContainer']['Directory'])) {
+            foreach ($data['MediaContainer']['Directory'] as $dir) {
+                $libraries[] = [
+                    'id' => $dir['key'],
+                    'name' => $dir['title'],
+                    'type' => $dir['type']
+                ];
+            }
+        }
+
+        echo json_encode(['success' => true, 'libraries' => $libraries]);
+        exit;
+    }
+    elseif ($action === 'scan') {
+        if (!$libraryId) {
+            echo json_encode(['error' => 'Missing library ID']);
+            exit;
+        }
+
+        $url = rtrim($baseUrl, '/') . "/library/sections/$libraryId/refresh";
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            "X-Plex-Token: $token"
+        ]);
+
+        $res = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode === 200) {
+            echo json_encode(['success' => true, 'message' => 'Scan started']);
+        } else {
+            echo json_encode(['error' => "Plex API Error: HTTP $httpCode"]);
+        }
+        exit;
+    }
+}
+
+// --- EMBY LOGIC ---
+if ($type === 'emby') {
+    if ($action === 'list') {
+        // Use /Items to list top-level views (libraries)
+        $url = rtrim($baseUrl, '/') . '/Items?Recursive=false&IncludeItemTypes=CollectionFolder,UserView';
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            "X-Emby-Token: $token",
+            "Accept: application/json"
+        ]);
+
+        $res = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode !== 200) {
+            echo json_encode(['error' => "Emby API Error: HTTP $httpCode"]);
+            exit;
+        }
+
+        $data = json_decode($res, true);
+        $libraries = [];
+
+        $items = $data['Items'] ?? [];
+        foreach ($items as $item) {
+            $libraries[] = [
+                'id' => $item['Id'],
+                'name' => $item['Name'],
+                'type' => $item['CollectionType'] ?? $item['Type']
+            ];
+        }
+
+        echo json_encode(['success' => true, 'libraries' => $libraries]);
+        exit;
+    }
+    elseif ($action === 'scan') {
+        // Emby Global Scan or Specific Library Scan
+        if ($libraryId === 'all') {
+             $url = rtrim($baseUrl, '/') . "/Library/Refresh";
+        } elseif ($libraryId) {
+             $url = rtrim($baseUrl, '/') . "/Items/$libraryId/Refresh?Recursive=true&ImageRefreshMode=Default&MetadataRefreshMode=Default&ReplaceAllMetadata=false&ReplaceAllImages=false";
+        } else {
+             echo json_encode(['error' => 'Missing library ID']);
+             exit;
+        }
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_POST, true); // POST for scanning
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            "X-Emby-Token: $token"
+        ]);
+
+        $res = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        // Emby usually returns 204 for success
+        if ($httpCode === 200 || $httpCode === 204) {
+            echo json_encode(['success' => true, 'message' => 'Scan started']);
+        } else {
+            echo json_encode(['error' => "Emby API Error: HTTP $httpCode"]);
+        }
+        exit;
+    }
+}
+
+echo json_encode(['error' => 'Invalid parameters or server type']);
+?>


### PR DESCRIPTION
Implemented a new feature to allow admins to list libraries from connected Plex and Emby servers and trigger a scan on them.

1.  **Backend (`library_actions.php`):**
    *   Securely handles API requests (Admin only).
    *   Decentralizes credentials from `servers.json`.
    *   Implements Plex Scan logic: `GET /library/sections/{id}/refresh`.
    *   Implements Emby Scan logic: `POST /Items/{id}/Refresh`.

2.  **Frontend (`index.php`):**
    *   Added "Libraries" button to top bar (Admin only).
    *   Added Modal for library management.
    *   Added JS to fetch and display libraries with "Scan" buttons.

Verified with Playwright script `verify_libraries.py` and visual inspection of screenshot.

---
*PR created automatically by Jules for task [4134728584485551323](https://jules.google.com/task/4134728584485551323) started by @Tophicles*