### PR TITLE
Remove redundant server type label from server cards

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -443,7 +443,6 @@ function renderServerGrid() {
         card.innerHTML = `
             ${dragHandle}
             <div class="server-name">${esc(server.name)}</div>
-            <div class="server-type">${esc(server.type)}</div>
             <div class="server-status">
                 <div class="status-dot ${isActive ? 'active server-' + esc(server.type) : ''}"></div>
                 ${isActive ? `${sessions.length} playing` : 'Idle'}


### PR DESCRIPTION
- Removed the explicit server type label (e.g., "PLEX", "EMBY") from the server cards in `assets/js/main.js`.
- The cards are already grouped by section headers (e.g., "PLEX SERVERS"), making the individual label redundant.
- Verified visual cleanliness via screenshot.