### PR TITLE
Responsive Item Modal & Media Info

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -915,6 +915,37 @@ body {
   .user-mobile { display: inline; font-weight: bold; cursor: pointer; }
   .clock-full { display: none; }
   .clock-short { display: inline; }
+
+  /* Modal Responsive */
+  .modal-header-new {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  .modal-poster {
+    margin-bottom: 16px;
+  }
+  .modal-poster img {
+    width: 140px; /* Slightly smaller on mobile */
+  }
+  .modal-meta {
+    justify-content: center;
+  }
+  .status-badge-fixed, .playmethod-badge-fixed {
+    position: static;
+    display: inline-block;
+    margin-bottom: 8px;
+  }
+  .modal-playback-info-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    text-align: center;
+  }
+  .modal-playback-info {
+    padding-right: 0;
+  }
 }
 
 form input, form select, form button { padding:8px 12px; font-size:0.9rem; background:var(--bg); color:var(--text); border:1px solid var(--border); border-radius:4px; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -979,6 +979,48 @@ async function showItemDetails(serverName, itemId, serverType) {
             html += '</div>';
         }
 
+        // File Info
+        const hasFileInfo = item.videoCodec || item.audioCodec || item.resolution || item.container || item.path;
+        if (hasFileInfo) {
+             html += '<div class="modal-details" style="margin-top: 12px; background: rgba(0,0,0,0.2);">';
+
+             if (item.videoCodec) {
+                html += `
+                    <div class="modal-detail-item">
+                        <div class="modal-detail-label">Video</div>
+                        <div class="modal-detail-value">${esc(item.videoCodec.toUpperCase())}${item.resolution ? ' ' + esc(item.resolution) : ''}</div>
+                    </div>
+                `;
+             }
+             if (item.audioCodec) {
+                html += `
+                    <div class="modal-detail-item">
+                        <div class="modal-detail-label">Audio</div>
+                        <div class="modal-detail-value">${esc(item.audioCodec.toUpperCase())}</div>
+                    </div>
+                `;
+             }
+             if (item.container) {
+                html += `
+                    <div class="modal-detail-item">
+                        <div class="modal-detail-label">Container</div>
+                        <div class="modal-detail-value">${esc(item.container.toUpperCase())}</div>
+                    </div>
+                `;
+             }
+
+             html += '</div>';
+
+             if (item.path) {
+                html += `
+                    <div style="margin-top: 12px; padding: 12px; background: rgba(0,0,0,0.2); border-radius: 8px; font-family: monospace; font-size: 0.85rem; word-break: break-all; color: #aaa;">
+                        <div style="font-size: 0.7rem; text-transform: uppercase; margin-bottom: 4px; color: #666;">File Path</div>
+                        ${esc(item.path)}
+                    </div>
+                `;
+             }
+        }
+
         // Current playback info at the bottom
         if (sessionData) {
             const isLive = !sessionData.duration || sessionData.duration <= 0 || !isFinite(sessionData.duration);


### PR DESCRIPTION
This change improves the item details modal by making it responsive on mobile devices and adding technical media information.

### Changes
1.  **Backend (`get_item_details.php`)**:
    -   Added logic to extract `videoCodec`, `audioCodec`, `resolution`, `container`, and `path` for both Plex and Emby/Jellyfin servers.
    -   For Emby/Jellyfin, it iterates through `MediaStreams` and checks `Path` at the item or source level.
    -   For Plex, it extracts data from the `Media` and `Part` objects.

2.  **Frontend Logic (`assets/js/main.js`)**:
    -   Updated `showItemDetails` to check for the presence of the new file info fields.
    -   Added a new `modal-details` section to display Video, Audio, and Container info.
    -   Added a separate block to display the File Path in a monospace font.

3.  **Styling (`assets/css/style.css`)**:
    -   Added a `@media (max-width: 768px)` query.
    -   Targeted `.modal-header-new` to use `flex-direction: column` on mobile.
    -   Centered the poster and text content on mobile.
    -   Adjusted badge and playback info layout for smaller screens.

### Verification
-   Created a mock `get_item_details.php` returning sample data with all new fields.
-   Used Playwright to capture screenshots of the modal in both desktop (1280x720) and mobile (375x667) viewports.
-   Verified that the desktop layout remains side-by-side while the mobile layout stacks correctly.
-   Verified that technical details and file path are displayed correctly.

---
*PR created automatically by Jules for task [1986500911000104678](https://jules.google.com/task/1986500911000104678) started by @Tophicles*