### PR TITLE
fix: re-apply modal changes for mobile layout and media info

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -915,6 +915,37 @@ body {
   .user-mobile { display: inline; font-weight: bold; cursor: pointer; }
   .clock-full { display: none; }
   .clock-short { display: inline; }
+
+  /* Modal Responsive */
+  .modal-header-new {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  .modal-poster {
+    margin-bottom: 16px;
+  }
+  .modal-poster img {
+    width: 140px; /* Slightly smaller on mobile */
+  }
+  .modal-meta {
+    justify-content: center;
+  }
+  .status-badge-fixed, .playmethod-badge-fixed {
+    position: static;
+    display: inline-block;
+    margin-bottom: 8px;
+  }
+  .modal-playback-info-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    text-align: center;
+  }
+  .modal-playback-info {
+    padding-right: 0;
+  }
 }
 
 form input, form select, form button { padding:8px 12px; font-size:0.9rem; background:var(--bg); color:var(--text); border:1px solid var(--border); border-radius:4px; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -979,6 +979,90 @@ async function showItemDetails(serverName, itemId, serverType) {
             html += '</div>';
         }
 
+        // File Info
+        const hasFileInfo = item.videoCodec || item.audioCodec || item.resolution || item.container || item.path;
+        if (hasFileInfo) {
+             html += '<div class="modal-details" style="margin-top: 12px; background: rgba(0,0,0,0.2);">';
+
+             if (item.videoCodec) {
+                html += `
+                    <div class="modal-detail-item">
+                        <div class="modal-detail-label">Video</div>
+                        <div class="modal-detail-value">${esc(item.videoCodec.toUpperCase())}${item.resolution ? ' ' + esc(item.resolution) : ''}</div>
+                    </div>
+                `;
+             }
+             if (item.audioCodec) {
+                html += `
+                    <div class="modal-detail-item">
+                        <div class="modal-detail-label">Audio</div>
+                        <div class="modal-detail-value">${esc(item.audioCodec.toUpperCase())}</div>
+                    </div>
+                `;
+             }
+             if (item.container) {
+                html += `
+                    <div class="modal-detail-item">
+                        <div class="modal-detail-label">Container</div>
+                        <div class="modal-detail-value">${esc(item.container.toUpperCase())}</div>
+                    </div>
+                `;
+             }
+
+             html += '</div>';
+
+             if (item.path) {
+                html += `
+                    <div style="margin-top: 12px; padding: 12px; background: rgba(0,0,0,0.2); border-radius: 8px; font-family: monospace; font-size: 0.85rem; word-break: break-all; color: #aaa;">
+                        <div style="font-size: 0.7rem; text-transform: uppercase; margin-bottom: 4px; color: #666;">File Path</div>
+                        ${esc(item.path)}
+                    </div>
+                `;
+             }
+        }
+
+        // File Info
+        const hasFileInfo = item.videoCodec || item.audioCodec || item.resolution || item.container || item.path;
+        if (hasFileInfo) {
+             html += '<div class="modal-details" style="margin-top: 12px; background: rgba(0,0,0,0.2);">';
+
+             if (item.videoCodec) {
+                html += `
+                    <div class="modal-detail-item">
+                        <div class="modal-detail-label">Video</div>
+                        <div class="modal-detail-value">${esc(item.videoCodec.toUpperCase())}${item.resolution ? ' ' + esc(item.resolution) : ''}</div>
+                    </div>
+                `;
+             }
+             if (item.audioCodec) {
+                html += `
+                    <div class="modal-detail-item">
+                        <div class="modal-detail-label">Audio</div>
+                        <div class="modal-detail-value">${esc(item.audioCodec.toUpperCase())}</div>
+                    </div>
+                `;
+             }
+             if (item.container) {
+                html += `
+                    <div class="modal-detail-item">
+                        <div class="modal-detail-label">Container</div>
+                        <div class="modal-detail-value">${esc(item.container.toUpperCase())}</div>
+                    </div>
+                `;
+             }
+
+             html += '</div>';
+
+             if (item.path) {
+                html += `
+                    <div style="margin-top: 12px; padding: 12px; background: rgba(0,0,0,0.2); border-radius: 8px; font-family: monospace; font-size: 0.85rem; word-break: break-all; color: #aaa;">
+                        <div style="font-size: 0.7rem; text-transform: uppercase; margin-bottom: 4px; color: #666;">File Path</div>
+                        ${esc(item.path)}
+                    </div>
+                `;
+             }
+        }
+
         // Current playback info at the bottom
         if (sessionData) {
             const isLive = !sessionData.duration || sessionData.duration <= 0 || !isFinite(sessionData.duration);


### PR DESCRIPTION
- Re-applied extraction logic in `get_item_details.php` for media codecs and paths.
- Re-applied frontend logic in `assets/js/main.js` to display the extracted media info.
- Verified `assets/css/style.css` contains the necessary responsive styles.