### PR TITLE
feat: Add tech badges and center them on mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -931,6 +931,9 @@ body {
   .modal-meta {
     justify-content: center;
   }
+  .modal-tech-badges {
+    justify-content: center;
+  }
   .status-badge-fixed, .playmethod-badge-fixed {
     position: static;
     display: inline-block;
@@ -963,4 +966,23 @@ form button:hover { background:#45a049; }
   0% { box-shadow: 0 0 5px rgba(76, 175, 80, 0.4); }
   50% { box-shadow: 0 0 20px rgba(76, 175, 80, 0.6); }
   100% { box-shadow: 0 0 5px rgba(76, 175, 80, 0.4); }
+}
+
+.tech-badge {
+  display: inline-block;
+  padding: 2px 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #eee;
+  text-transform: uppercase;
+}
+.modal-tech-badges {
+  margin-bottom: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: -8px; /* Slightly pull up closer to meta */
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -170,6 +170,17 @@ function getQualityBadge(width, height) {
     return '';
 }
 
+// Helper to format audio channels
+function formatAudioChannels(channels) {
+    if (!channels) return '';
+    const ch = parseFloat(channels);
+    if (ch === 6) return '5.1';
+    if (ch === 8) return '7.1';
+    if (ch === 2) return '2.0';
+    if (ch === 1) return '1.0';
+    return channels;
+}
+
 // Get play method icon
 function getPlayMethodIcon(playMethod) {
     if (!playMethod) return '';
@@ -933,6 +944,29 @@ async function showItemDetails(serverName, itemId, serverType) {
         }
         html += '</div>';
 
+        // Tech Badges
+        const resolution = item.resolution ? item.resolution.split('x') : [];
+        const height = resolution.length > 1 ? parseInt(resolution[1]) : 0;
+        const width = resolution.length > 0 ? parseInt(resolution[0]) : 0;
+        const qualityBadge = getQualityBadge(width, height);
+
+        const hasTechInfo = qualityBadge || item.container || item.audioCodec;
+
+        if (hasTechInfo) {
+            html += '<div class="modal-tech-badges">';
+            if (qualityBadge) {
+                html += `<div class="tech-badge">${esc(qualityBadge)}</div>`;
+            }
+            if (item.container) {
+                html += `<div class="tech-badge">${esc(item.container)}</div>`;
+            }
+            if (item.audioCodec) {
+                const audioCh = formatAudioChannels(item.audioChannels);
+                html += `<div class="tech-badge">${esc(item.audioCodec)} ${audioCh ? esc(audioCh) : ''}</div>`;
+            }
+            html += '</div>';
+        }
+
         // Overview inline with poster
         if (item.overview) {
             html += `<div class="modal-overview-inline">${esc(item.overview)}</div>`;
@@ -979,63 +1013,31 @@ async function showItemDetails(serverName, itemId, serverType) {
             html += '</div>';
         }
 
-        // File Info
-        const hasFileInfo = item.videoCodec || item.audioCodec || item.resolution || item.container || item.path;
-        if (hasFileInfo) {
-             html += '<div class="modal-details" style="margin-top: 12px; background: rgba(0,0,0,0.2);">';
+        // File Info (Path only, tech details moved to badges)
+        if (item.path) {
+            const path = item.path;
+            const lastSlash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+            let dir = path;
+            let file = '';
 
-             if (item.videoCodec) {
-                html += `
-                    <div class="modal-detail-item">
-                        <div class="modal-detail-label">Video</div>
-                        <div class="modal-detail-value">${esc(item.videoCodec.toUpperCase())}${item.resolution ? ' ' + esc(item.resolution) : ''}</div>
+            if (lastSlash > -1) {
+                dir = path.substring(0, lastSlash);
+                file = path.substring(lastSlash + 1);
+            }
+
+            html += `
+                <div style="margin-top: 12px; padding: 12px; background: rgba(0,0,0,0.2); border-radius: 8px; font-family: monospace; font-size: 0.85rem; word-break: break-all; color: #aaa;">
+                    <div style="margin-bottom: 8px;">
+                        <div style="font-size: 0.7rem; text-transform: uppercase; margin-bottom: 2px; color: #666;">Root Path</div>
+                        ${esc(dir)}
                     </div>
-                `;
-             }
-             if (item.audioCodec) {
-                html += `
-                    <div class="modal-detail-item">
-                        <div class="modal-detail-label">Audio</div>
-                        <div class="modal-detail-value">${esc(item.audioCodec.toUpperCase())}${item.audioChannels ? ' ' + esc(item.audioChannels) : ''}</div>
-                    </div>
-                `;
-             }
-             if (item.container) {
-                html += `
-                    <div class="modal-detail-item">
-                        <div class="modal-detail-label">Container</div>
-                        <div class="modal-detail-value">${esc(item.container.toUpperCase())}</div>
-                    </div>
-                `;
-             }
-
-             html += '</div>';
-
-             if (item.path) {
-                const path = item.path;
-                const lastSlash = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
-                let dir = path;
-                let file = '';
-
-                if (lastSlash > -1) {
-                    dir = path.substring(0, lastSlash);
-                    file = path.substring(lastSlash + 1);
-                }
-
-                html += `
-                    <div style="margin-top: 12px; padding: 12px; background: rgba(0,0,0,0.2); border-radius: 8px; font-family: monospace; font-size: 0.85rem; word-break: break-all; color: #aaa;">
-                        <div style="margin-bottom: 8px;">
-                            <div style="font-size: 0.7rem; text-transform: uppercase; margin-bottom: 2px; color: #666;">Root Path</div>
-                            ${esc(dir)}
-                        </div>
-                        ${file ? `
-                        <div>
-                            <div style="font-size: 0.7rem; text-transform: uppercase; margin-bottom: 2px; color: #666;">Filename</div>
-                            <span style="color: #fff; font-weight: 600;">${esc(file)}</span>
-                        </div>` : ''}
-                    </div>
-                `;
-             }
+                    ${file ? `
+                    <div>
+                        <div style="font-size: 0.7rem; text-transform: uppercase; margin-bottom: 2px; color: #666;">Filename</div>
+                        <span style="color: #aaa; font-weight: 600;">${esc(file)}</span>
+                    </div>` : ''}
+                </div>
+            `;
         }
 
         // Current playback info at the bottom


### PR DESCRIPTION
- Added `.tech-badge` and `.modal-tech-badges` CSS classes.
- Updated `assets/js/main.js` to display resolution, container, and audio badges in the item modal.
- Formatted audio channels (e.g., 6 -> 5.1).
- Styled filename in path to match path color.
- Centered tech badges on mobile devices in `assets/css/style.css`.