### PR TITLE
Consolidate Admin and Library modals into Server View

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -37,6 +37,7 @@ This guide outlines the files required and the steps needed to deploy the MultiD
     *   `assets/css/` - Stylesheets.
     *   `assets/js/` - JavaScript logic.
     *   `assets/img/` - Logos and favicons.
+*   `os_helpers/` - Directory containing Linux setup scripts.
 *   `screenshots/` - Directory containing UI images (optional, for README).
 *   `README.md` - Documentation.
 
@@ -85,7 +86,7 @@ location /dash {
     # Deny access to sensitive files
     location ~ \.(json|log|php)$ {
         # Allow specific PHP entry points
-        location ~ ^/dash/(index|login|setup|logout|proxy|get_|add_|update_|delete_|manage_|view_logs|library_actions)\.php$ {
+        location ~ ^/dash/(index|login|setup|logout|proxy|get_|add_|update_|delete_|manage_|view_logs|library_actions|ssh_manager|log_event)\.php$ {
             include snippets/fastcgi-php.conf;
             fastcgi_pass unix:/var/run/php/php-fpm.sock;
         }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A lightweight, self-hosted dashboard for monitoring multiple Plex, Emby, and Jel
 *   **Search & Filter:** Instantly filter servers and users. Matching user sessions are displayed directly on the server card with visual icons.
 *   **Real-time Updates:** Auto-refreshing status for "Now Watching" and dashboard users.
 *   **Dynamic Server Management:** Easily add and edit servers using a modal interface with protocol selection and validation.
-*   **Server Administration:** Check for updates and remotely restart servers via SSH or API.
+*   **Server Administration:** Check for updates and remotely restart servers via SSH (Linux) or API (Emby/Jellyfin).
 *   **Library Management:** List and trigger scans for media libraries on connected Plex, Emby, and Jellyfin servers.
 *   **User Management:** Built-in authentication with Admin and Viewer roles.
 *   **Logging System:** Comprehensive system logging with a built-in "tailable" log viewer.
@@ -34,6 +34,10 @@ Easily add, edit, and reorder your media servers via a user-friendly modal.
 ### User Administration
 Manage dashboard users directly from the interface.
 ![User Management](screenshots/users.png)
+
+### System Logs
+View detailed system and error logs with a live tail view.
+![System Logs](screenshots/logs.png)
 
 ## Installation
 
@@ -76,19 +80,31 @@ Go to **Admin > Server Administration > SSH Keys** in the dashboard and click "G
 ### 2. Configure Remote Media Server (Automated Method)
 We provide a helper script to automate the secure setup process.
 
-1.  Transfer the script to your media server:
-    ```bash
-    scp os_helpers/linux_setup.sh user@your-media-server:/tmp/
-    ```
-2.  SSH into your media server and run the script:
-    ```bash
-    ssh user@your-media-server
-    chmod +x /tmp/linux_setup.sh
-    sudo /tmp/linux_setup.sh
-    ```
-3.  Choose **Option 1 (Install)** and paste the Public Key when prompted.
+1.  **Download the script on your media server:**
+    SSH into your media server and download the helper script using `curl` or `wget`:
 
-To remove the configuration later, simply run the script again and choose **Option 2 (Uninstall)**.
+    ```bash
+    # Using curl
+    curl -O https://your-dashboard-url/dash/os_helpers/linux_setup.sh
+
+    # OR using wget
+    wget https://your-dashboard-url/dash/os_helpers/linux_setup.sh
+    ```
+    *Replace `https://your-dashboard-url/dash/` with the actual URL where you installed the dashboard.*
+
+2.  **Run the script:**
+    ```bash
+    chmod +x linux_setup.sh
+    sudo ./linux_setup.sh install
+    ```
+
+3.  **Paste Public Key:**
+    When prompted, paste the Public Key copied from the dashboard.
+
+To remove the configuration later, simply run the script again with the `uninstall` argument:
+```bash
+sudo ./linux_setup.sh uninstall
+```
 
 ### 3. Configure Remote Media Server (Manual Method)
 If you prefer to configure the server manually, follow these steps:
@@ -153,7 +169,7 @@ The above instructions adhere to the **Principle of Least Privilege**:
 In the **Add/Edit Server** modal for your server:
 *   Select **Linux** as the Operating System.
 *   If your server uses a standard SSH port (22), no further configuration is needed.
-*   The dashboard will automatically connect to the server's IP (derived from the Proxy URL) as the `mediasvc` user and execute the correct restart command for your server type.
+*   The dashboard will automatically connect to the server's IP (derived from the Proxy URL) as the `mediasvc` user. You can verify connectivity using the **Check SSH** button.
 
 ## Configuration
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -397,40 +397,15 @@ async function testServerUpdate(serverId) {
 
 // Server Admin Logic
 if (IS_ADMIN) {
-    const adminBtn = document.getElementById('server-admin-btn');
-    if (adminBtn) {
-        adminBtn.addEventListener('click', openServerAdminModal);
-    }
-
-    // SSH Keys Button (inside Admin Modal)
-    const sshBtn = document.getElementById('ssh-keys-btn');
+    // SSH Keys Button (in top menu)
+    const sshBtn = document.getElementById('ssh-keys-nav-btn');
     if (sshBtn) {
         sshBtn.addEventListener('click', openSSHModal);
     }
 }
 
-function openServerAdminModal() {
-    const modal = document.getElementById('server-admin-modal');
-    modal.classList.add('visible');
-    renderServerAdminList();
-}
-
-function closeServerAdminModal() {
-    document.getElementById('server-admin-modal').classList.remove('visible');
-}
-
-// Close on click outside
-document.getElementById('server-admin-modal').addEventListener('click', function(e) {
-    if (e.target === this) {
-        closeServerAdminModal();
-    }
-});
-
 // SSH Manager Logic
 async function openSSHModal() {
-    // Hide Admin Modal temporarily (or stack on top, but hiding is cleaner)
-    closeServerAdminModal();
-
     const modal = document.getElementById('ssh-modal');
     modal.classList.add('visible');
 
@@ -457,8 +432,6 @@ async function openSSHModal() {
 
 function closeSSHModal() {
     document.getElementById('ssh-modal').classList.remove('visible');
-    // Re-open Admin Modal
-    openServerAdminModal();
 }
 
 document.getElementById('ssh-modal').addEventListener('click', function(e) {
@@ -522,79 +495,6 @@ if (sshCopyBtn) {
     });
 }
 
-function renderServerAdminList() {
-    const container = document.getElementById('admin-server-list');
-    container.innerHTML = '';
-
-    SERVERS.forEach(async server => {
-        const item = document.createElement('div');
-        item.className = 'admin-server-item';
-
-        const sessions = ALL_SESSIONS[server.name] || [];
-        const isActive = sessions.length > 0;
-        const status = isActive ? `<span style="color:#4caf50;">Online (${sessions.length} active)</span>` : '<span style="color:#aaa;">Idle</span>';
-        const isLinux = !server.os_type || server.os_type === 'linux';
-
-        let actionsHtml = `
-            <button class="admin-action-btn" title="Check for Updates" onclick="checkServerUpdate('${esc(server.id)}', this)">
-                <i class="fa-solid fa-rotate"></i>
-            </button>
-            <button class="admin-action-btn" title="Simulate Update Available" onclick="testServerUpdate('${esc(server.id)}')">
-                <i class="fa-solid fa-flask"></i>
-            </button>
-        `;
-
-        if (isLinux) {
-            actionsHtml += `<span id="ssh-controls-${esc(server.id)}">`;
-            if (server.ssh_initialized) {
-                actionsHtml += `<i class="fa-solid fa-spinner fa-spin"></i>`;
-                // Fetch status asynchronously
-                fetchServerStatus(server.id);
-            } else {
-                actionsHtml += `
-                    <button class="admin-action-btn" title="Check SSH Connection" onclick="deployServerKey('${esc(server.id)}')">
-                        <i class="fa-solid fa-key"></i> Check SSH
-                    </button>
-                `;
-            }
-            actionsHtml += `</span>`;
-        }
-
-        if (server.type !== 'plex') {
-            actionsHtml += `
-                <button class="admin-action-btn danger" title="Restart Server (API)" onclick="restartServer('${esc(server.id)}', '${esc(server.name)}')">
-                    <i class="fa-solid fa-power-off"></i>
-                </button>
-            `;
-        }
-
-        let osIcon = 'fa-server';
-        if (!server.os_type || server.os_type === 'linux') osIcon = 'fa-linux';
-        else if (server.os_type === 'docker') osIcon = 'fa-docker';
-        else if (server.os_type === 'windows') osIcon = 'fa-windows';
-        else if (server.os_type === 'macos') osIcon = 'fa-apple';
-        else if (server.os_type === 'other') osIcon = 'fa-server';
-
-        item.innerHTML = `
-            <div style="display:flex; align-items:center; gap:12px;">
-                <div class="admin-os-badge" title="OS: ${esc(server.os_type || 'linux')}">
-                    <i class="fa-brands ${osIcon}"></i>
-                </div>
-                <div class="admin-server-info">
-                    <div class="admin-server-name">${esc(server.name)}</div>
-                    <div class="admin-server-details">
-                        Type: ${esc(server.type.toUpperCase())} • Version: ${esc(server.version || 'Unknown')} • ${status}
-                    </div>
-                </div>
-            </div>
-            <div class="admin-server-actions">
-                ${actionsHtml}
-            </div>
-        `;
-        container.appendChild(item);
-    });
-}
-
 const SERVER_TRANSITIONS = {}; // { serverId: 'ssh_start'|'ssh_stop'|'ssh_restart' }
 
 async function fetchServerStatus(serverId) {
@@ -602,8 +502,8 @@ async function fetchServerStatus(serverId) {
         const res = await fetch(`proxy.php?id=${encodeURIComponent(serverId)}&action=ssh_status`);
         const data = await res.json();
 
-        // Update both Admin Modal and Header controls
-        const containers = document.querySelectorAll(`[id^="ssh-controls-${serverId}"], [id^="js-header-controls-${serverId}"]`);
+        // Update Header controls
+        const containers = document.querySelectorAll(`[id^="js-header-controls-${serverId}"]`);
 
         containers.forEach(container => {
             if (data.success) {
@@ -731,7 +631,7 @@ function pollServerStatus(serverId) {
 }
 
 async function deployServerKey(serverId) {
-    const containers = document.querySelectorAll(`[id^="ssh-controls-${serverId}"], [id^="js-header-controls-${serverId}"]`);
+    const containers = document.querySelectorAll(`[id^="js-header-controls-${serverId}"]`);
     containers.forEach(c => c.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Verifying...');
 
     try {
@@ -762,7 +662,7 @@ async function deployServerKey(serverId) {
             showModalAlert('Connection Failed: ' + esc(data.error) + '\n\nPlease ensure you have run the "linux_setup.sh" script on the target server.');
             // Revert button
             const server = SERVERS.find(s => s.id === serverId);
-            const containers = document.querySelectorAll(`[id^="ssh-controls-${serverId}"], [id^="js-header-controls-${serverId}"]`);
+            const containers = document.querySelectorAll(`[id^="js-header-controls-${serverId}"]`);
             if (server) {
                 containers.forEach(c => {
                     c.innerHTML = `
@@ -792,7 +692,13 @@ async function checkServerUpdate(serverId, btn) {
         server.version = info.version;
         server.hasUpdate = info.hasUpdate;
         renderServerGrid();
-        renderServerAdminList(); // Refresh list to show new version/status if changed
+
+        // Refresh single server view title/buttons
+        if (currentView === 'sessions' && selectedServerId === serverId) {
+            showSessionsView(serverId, server.name);
+        }
+
+        showModalAlert(`Version Checked: v${info.version}` + (info.hasUpdate ? ' (Update Available)' : ''));
     } else {
         showModalAlert('Failed to fetch server info');
     }
@@ -2279,110 +2185,7 @@ document.getElementById('users-modal').addEventListener('click', function(e) {
     }
 });
 
-// Libraries Management
-if (IS_ADMIN) {
-    const libBtn = document.getElementById('libraries-btn');
-    if (libBtn) {
-        libBtn.addEventListener('click', function() {
-            openLibrariesModal();
-        });
-    }
-}
-
-function openLibrariesModal() {
-    const modal = document.getElementById('libraries-modal');
-    modal.classList.add('visible');
-
-    // Populate Server Select
-    const select = document.getElementById('library-server-select');
-    select.innerHTML = '<option value="">-- Select a Server --</option>';
-
-    SERVERS.forEach(server => {
-        const option = document.createElement('option');
-        option.value = server.name;
-        option.textContent = `${server.name} (${server.type})`;
-        select.appendChild(option);
-    });
-
-    // Reset View
-    document.getElementById('libraries-list').innerHTML = '';
-    document.getElementById('libraries-empty').style.display = 'block';
-
-    // Event Listener for Select
-    select.onchange = function() {
-        if (this.value) {
-            fetchLibraries(this.value);
-        } else {
-            document.getElementById('libraries-list').innerHTML = '';
-            document.getElementById('libraries-empty').style.display = 'block';
-        }
-    };
-}
-
-function closeLibrariesModal() {
-    document.getElementById('libraries-modal').classList.remove('visible');
-}
-
-// Close libraries modal when clicking outside
-document.getElementById('libraries-modal').addEventListener('click', function(e) {
-    if (e.target === this) {
-        closeLibrariesModal();
-    }
-});
-
-async function fetchLibraries(serverName) {
-    const list = document.getElementById('libraries-list');
-    const empty = document.getElementById('libraries-empty');
-    const loading = document.getElementById('libraries-loading');
-
-    list.innerHTML = '';
-    empty.style.display = 'none';
-    loading.style.display = 'block';
-
-    try {
-        const response = await fetch(`library_actions.php?action=list&server=${encodeURIComponent(serverName)}`);
-        const data = await response.json();
-
-        loading.style.display = 'none';
-
-        if (data.success) {
-            if (data.libraries.length === 0) {
-                empty.textContent = 'No libraries found.';
-                empty.style.display = 'block';
-                return;
-            }
-
-            // Render libraries
-            data.libraries.forEach(lib => {
-                const item = document.createElement('div');
-                item.className = 'user-item'; // Reuse existing style
-                item.style.background = 'rgba(0,0,0,0.3)';
-
-                item.innerHTML = `
-                    <div class="user-item-info">
-                        <div class="user-item-username">${esc(lib.name)}</div>
-                        <div class="user-item-meta">
-                            Type: ${esc(lib.type)}
-                        </div>
-                    </div>
-                    <div class="user-item-actions">
-                        <button class="btn primary" onclick="scanLibrary('${esc(serverName)}', '${esc(lib.id)}', '${esc(lib.name)}', this)"><i class="fa-solid fa-arrows-rotate"></i> Scan</button>
-                    </div>
-                `;
-                list.appendChild(item);
-            });
-
-        } else {
-            empty.textContent = 'Error: ' + (data.error || 'Unknown error');
-            empty.style.display = 'block';
-        }
-    } catch (error) {
-        console.error('Error fetching libraries:', error);
-        loading.style.display = 'none';
-        empty.textContent = 'Failed to fetch libraries';
-        empty.style.display = 'block';
-    }
-}
+// (Libraries Management Removed)
 
 async function scanLibrary(serverName, libraryId, libraryName, btn) {
     if (btn) {

--- a/index.php
+++ b/index.php
@@ -50,27 +50,12 @@ $isAdmin = isAdmin();
       </div>
       <button class="btn" id="reorder-btn" title="Toggle Reorder Mode">Reorder</button>
       <button class="btn" id="users-btn" title="Manage Users">Users</button>
-      <button class="btn" id="libraries-btn" title="Manage Libraries">Libraries</button>
-      <button class="btn" id="server-admin-btn" title="Server Administration">Admin</button>
+      <button class="btn" id="ssh-keys-nav-btn" title="SSH Key Manager">SSH Keys</button>
       <button class="btn" id="logs-btn" title="View System Logs" onclick="window.open('view_logs.php', 'SystemLogs')">Logs</button>
       <?php endif; ?>
       <button class="btn" id="activeonly-btn" title="Show Only Active Servers">Active Only</button>
       <button class="btn" id="showall-btn" title="Toggle All Sessions">Show All</button>
       <button class="btn danger" onclick="window.location.href='logout.php'">Logout</button>
-    </div>
-  </div>
-</div>
-
-<!-- Server Admin Modal -->
-<div id="server-admin-modal" class="modal">
-  <div class="modal-content" style="max-width: 900px;">
-    <span class="modal-close" onclick="closeServerAdminModal()">&times;</span>
-    <div id="server-admin-body" style="padding: 20px;">
-      <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:20px; margin-right: 40px;">
-        <h2 style="margin-bottom:0;">Server Administration</h2>
-        <button class="btn" id="ssh-keys-btn" title="SSH Key Manager"><i class="fa-solid fa-key"></i> SSH Keys</button>
-      </div>
-      <div id="admin-server-list" class="admin-server-list"></div>
     </div>
   </div>
 </div>
@@ -260,29 +245,6 @@ $isAdmin = isAdmin();
       <div class="users-list-container">
         <h3>Existing Users</h3>
         <div id="users-list"></div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<!-- Libraries Management Modal -->
-<div id="libraries-modal" class="modal">
-  <div class="modal-content">
-    <span class="modal-close" onclick="closeLibrariesModal()">&times;</span>
-    <div id="libraries-modal-body">
-      <h2 style="margin-bottom: 20px;">Manage Libraries</h2>
-
-      <div class="info-box" style="margin-bottom:20px; padding:15px; background:rgba(255,255,255,0.05); border-radius:6px;">
-        <label style="display:block; margin-bottom:10px;">Select Server:</label>
-        <select id="library-server-select" style="width:100%; max-width:300px; padding:10px; background:var(--bg); color:var(--text); border:1px solid var(--border); border-radius:4px;">
-           <option value="">-- Select a Server --</option>
-        </select>
-      </div>
-
-      <div id="libraries-list-container" style="min-height:200px;">
-         <div class="empty" id="libraries-loading" style="display:none;">Loading libraries...</div>
-         <div class="empty" id="libraries-empty">Select a server to view libraries.</div>
-         <div id="libraries-list" style="display:grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap:12px;"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Remove standalone 'Admin' and 'Libraries' modals and top-bar buttons.
- Add 'SSH Keys' button to top bar for direct access.
- Move 'Check Update' and 'Simulate Update' buttons to the individual Server View header.
- Clean up unused JS code for removed modals.
- Ensure 'Check SSH' button logic is preserved in Server View.