### PR TITLE
refactor: cleanup menu and move keys button to header

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -4,7 +4,28 @@
   --emby-color: #1f2f1f;
   --plex-color: #2f2f1f;
   --jellyfin-color: #2f1f2f;
+  --bg-hover: rgba(255, 255, 255, 0.08);
+  --bg-transparent: rgba(0,0,0,0.3);
+  --card-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  --modal-overlay: rgba(0,0,0,0.8);
 }
+
+[data-theme="light"] {
+  --bg: #f0f2f5;
+  --card: #ffffff;
+  --border: #e0e0e0;
+  --text: #333333;
+  --muted: #666666;
+  /* Accents stay mostly same, but server specific colors need to be lighter for background */
+  --emby-color: #f1f8e9; /* Light Green */
+  --plex-color: #fff8e1; /* Light Amber */
+  --jellyfin-color: #f3e5f5; /* Light Purple */
+  --bg-hover: rgba(0, 0, 0, 0.05);
+  --bg-transparent: rgba(0, 0, 0, 0.05);
+  --card-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  --modal-overlay: rgba(0,0,0,0.6);
+}
+
 body {
   margin:0;
   padding:16px;
@@ -15,7 +36,7 @@ body {
 .back-btn {
   background: var(--card);
   border: 1px solid var(--border);
-  color: white;
+  color: var(--text);
   padding: 8px 16px;
   border-radius: 6px;
   font-size: 0.9rem;
@@ -60,8 +81,8 @@ body {
   font-weight: 600;
 }
 .header-badge {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
   color: var(--text);
   padding: 6px 12px;
   border-radius: 6px;
@@ -74,7 +95,7 @@ body {
   box-sizing: border-box;
 }
 #header-reload-btn:hover .header-badge {
-   background: rgba(255, 255, 255, 0.2);
+   filter: brightness(1.2);
 }
 .menu-content {
   padding: 12px 16px;
@@ -96,12 +117,12 @@ body {
 }
 .user-info {
   font-size: 0.85rem;
-  color: #aaa;
+  color: var(--muted);
   padding: 6px 12px;
-  background: rgba(0,0,0,0.3);
+  background: var(--bg-transparent);
   border-radius: 6px;
   text-transform: capitalize;
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border);
   height: 32px;
   display: inline-flex;
   align-items: center;
@@ -329,7 +350,7 @@ body {
 }
 .server-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  box-shadow: var(--card-shadow);
 }
 .server-card.server-emby:hover {
   border-color: rgba(76, 175, 80, 0.6);
@@ -362,7 +383,7 @@ body {
 
 .server-match-preview {
   font-size: 0.85rem;
-  color: #ffffff;
+  color: var(--text);
   font-weight: 700;
   text-align: center;
   text-shadow: 0 1px 2px rgba(0,0,0,0.8);
@@ -377,7 +398,7 @@ body {
   gap: 6px;
 }
 .server-match-preview i {
-  color: #ffffff;
+  color: var(--text);
 }
 
 .server-name {
@@ -494,7 +515,7 @@ body {
   top: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0,0,0,0.8);
+  background-color: var(--modal-overlay);
   animation: fadeIn 0.3s;
 }
 @keyframes fadeIn {
@@ -573,12 +594,12 @@ body {
 }
 .modal-subtitle {
   font-size: 1.2rem;
-  color: rgba(255,255,255,0.7);
+  color: var(--muted);
   margin-bottom: 8px;
 }
 .modal-episode {
   font-size: 0.95rem;
-  color: rgba(255,255,255,0.6);
+  color: var(--muted);
   margin-bottom: 12px;
   font-style: italic;
 }
@@ -600,12 +621,14 @@ body {
 }
 .modal-overview {
   line-height: 1.6;
-  color: rgba(255,255,255,0.85);
+  color: var(--text);
+  opacity: 0.9;
   margin-bottom: 20px;
 }
 .modal-overview-inline {
   line-height: 1.6;
-  color: rgba(255,255,255,0.85);
+  color: var(--text);
+  opacity: 0.9;
   margin-top: 16px;
   flex: 1;
   max-height: 95px;
@@ -675,7 +698,7 @@ body {
 }
 .modal-playback-time {
   font-size: 0.9rem;
-  color: rgba(255,255,255,0.8);
+  color: var(--muted);
   text-align: center;
   margin-bottom: 5px;
 }
@@ -713,7 +736,7 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 12px;
   padding: 16px;
-  background: rgba(0,0,0,0.3);
+  background: var(--bg-transparent);
   border-radius: 8px;
   margin-top: 20px;
 }
@@ -735,14 +758,14 @@ body {
 
 /* User Management Modal */
 .user-form-container {
-  background: rgba(0,0,0,0.3);
+  background: var(--bg-transparent);
   padding: 20px;
   border-radius: 8px;
   margin-bottom: 30px;
 }
 .user-form-container h3 {
   margin-bottom: 15px;
-  color: #fff;
+  color: var(--text);
 }
 .form-row {
   display: grid;
@@ -752,10 +775,10 @@ body {
 }
 .users-list-container h3 {
   margin-bottom: 15px;
-  color: #fff;
+  color: var(--text);
 }
 .user-item {
-  background: rgba(0,0,0,0.3);
+  background: var(--bg-transparent);
   padding: 15px;
   border-radius: 6px;
   margin-bottom: 10px;
@@ -770,7 +793,7 @@ body {
 .user-item-username {
   font-weight: 600;
   font-size: 1rem;
-  color: #fff;
+  color: var(--text);
   margin-bottom: 4px;
   text-transform: capitalize;
 }
@@ -822,7 +845,7 @@ body {
 }
 .subtitle {
   font-size: 0.85rem;
-  color: rgba(255,255,255,0.7);
+  color: var(--muted);
   line-height: 1.1;
   white-space: nowrap;
   overflow: hidden;
@@ -834,7 +857,7 @@ body {
   letter-spacing:0.05em;
   opacity:0.9;
   padding-bottom:4px;
-  border-bottom:1px solid rgba(255,255,255,0.15);
+  border-bottom:1px solid var(--border);
   margin-bottom:6px;
   display: flex;
   justify-content: space-between;
@@ -865,7 +888,7 @@ body {
   font-size: 0.75rem;
   padding: 1px 4px;
 }
-.muted { font-size:0.7rem; color:rgba(255,255,255,0.7); margin-bottom:4px; }
+.muted { font-size:0.7rem; color:var(--muted); margin-bottom:4px; }
 .progress-bar { height:8px; background:#333; border-radius:4px; margin-top:2px; overflow:hidden; opacity:0.9; }
 .progress { height:100%; background:var(--accent); width:0%; transition:width 0.4s linear; }
 .paused .progress { background:#ffc107; }
@@ -915,15 +938,15 @@ body {
   width: 6px;
 }
 .modal-overview-inline::-webkit-scrollbar-track {
-  background: rgba(255,255,255,0.05);
+  background: var(--bg-hover);
   border-radius: 3px;
 }
 .modal-overview-inline::-webkit-scrollbar-thumb {
-  background: rgba(255,255,255,0.2);
+  background: var(--border);
   border-radius: 3px;
 }
 .modal-overview-inline::-webkit-scrollbar-thumb:hover {
-  background: rgba(255,255,255,0.3);
+  background: var(--muted);
 }
 
 /* Mobile Responsive */
@@ -958,7 +981,7 @@ body {
     flex-wrap: wrap;
     gap: 12px;
     padding-top: 8px;
-    border-top: 1px solid rgba(255,255,255,0.05);
+    border-top: 1px solid var(--border);
   }
   .top-bar-header {
     padding: 10px 12px;
@@ -1050,12 +1073,12 @@ form button:hover { background:#45a049; }
 .tech-badge {
   display: inline-block;
   padding: 2px 6px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
   border-radius: 4px;
   font-size: 0.75rem;
   font-weight: 600;
-  color: #eee;
+  color: var(--text);
   text-transform: uppercase;
 }
 .modal-tech-badges {
@@ -1069,13 +1092,27 @@ form button:hover { background:#45a049; }
 
 .server-version {
   font-size: 0.7rem;
-  color: #ccc;
+  color: var(--muted);
   margin-top: 2px;
+}
+
+.inline-library-item {
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+}
+.inline-library-item span {
+  color: var(--text);
 }
 
 .server-title-version {
   font-size: 0.8em;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--muted);
   margin-left: 8px;
   font-weight: normal;
 }
@@ -1096,7 +1133,7 @@ form button:hover { background:#45a049; }
   position: absolute;
   bottom: 8px;
   right: 8px;
-  color: rgba(255, 255, 255, 0.2);
+  color: var(--border);
   cursor: pointer;
   font-size: 0.8rem;
   transition: color 0.2s;
@@ -1113,7 +1150,7 @@ form button:hover { background:#45a049; }
   gap: 8px;
 }
 .admin-server-item {
-  background: rgba(0,0,0,0.3);
+  background: var(--bg-transparent);
   padding: 12px 16px;
   border-radius: 6px;
   display: flex;
@@ -1173,7 +1210,7 @@ form button:hover { background:#45a049; }
 
 /* SSH Manager */
 .ssh-status-box {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--bg-hover);
   padding: 15px;
   border-radius: 6px;
   margin-bottom: 20px;
@@ -1181,9 +1218,9 @@ form button:hover { background:#45a049; }
 .ssh-key-display {
   width: 100%;
   height: 100px;
-  background: #111;
-  color: #ccc;
-  border: 1px solid #444;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
   padding: 10px;
   font-family: monospace;
   font-size: 0.8rem;
@@ -1216,7 +1253,7 @@ form button:hover { background:#45a049; }
 }
 .ssh-agreement label {
   font-size: 0.9rem;
-  color: #ddd;
+  color: var(--text);
   line-height: 1.4;
   cursor: pointer;
 }
@@ -1237,6 +1274,10 @@ form button:hover { background:#45a049; }
 .server-header-enhanced.jellyfin { background: linear-gradient(to right, rgba(47, 31, 47, 0.9), rgba(47, 31, 47, 0.6)); border-left: 4px solid #aa00aa; }
 .server-header-enhanced.plex { background: linear-gradient(to right, rgba(47, 47, 31, 0.9), rgba(47, 47, 31, 0.6)); border-left: 4px solid #ffc107; }
 
+[data-theme="light"] .server-header-enhanced.emby { background: var(--emby-color); }
+[data-theme="light"] .server-header-enhanced.jellyfin { background: var(--jellyfin-color); }
+[data-theme="light"] .server-header-enhanced.plex { background: var(--plex-color); }
+
 .header-left, .header-center, .header-right {
     display: flex;
     align-items: center;
@@ -1253,11 +1294,11 @@ form button:hover { background:#45a049; }
     width: 28px;
     height: 28px;
     border-radius: 4px;
-    background: rgba(255,255,255,0.1);
-    border: 1px solid rgba(255,255,255,0.2);
+    background: var(--bg-hover);
+    border: 1px solid var(--border);
     margin-right: 10px;
     font-size: 1rem;
-    color: #eee;
+    color: var(--text);
 }
 
 /* Card OS Badge (Pinned Bottom Right) */
@@ -1265,48 +1306,49 @@ form button:hover { background:#45a049; }
     position: absolute;
     bottom: 6px;
     right: 6px;
-    color: #ccc;
+    color: var(--muted);
     font-size: 1.1rem;
     pointer-events: none;
     transition: color 0.2s;
     z-index: 1;
 }
 .server-card:hover .card-os-badge {
-    color: #fff;
+    color: var(--text);
 }
 
 /* Header buttons specific override */
 .header-right .admin-action-btn {
     padding: 6px 12px;
     font-size: 0.85rem;
-    background: rgba(0,0,0,0.3);
-    border-color: rgba(255,255,255,0.2);
+    background: var(--bg-transparent);
+    border-color: var(--border);
+    color: var(--text); /* Ensure visible text */
 }
 .header-right .admin-action-btn:hover {
-    background: rgba(255,255,255,0.1);
-    color: #fff;
-    border-color: #fff;
+    background: var(--bg-hover);
+    color: var(--text);
+    border-color: var(--text);
 }
 
 /* Admin OS Badge */
 .admin-os-badge {
     width: 40px;
     height: 40px;
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: var(--bg-hover);
+    border: 1px solid var(--border);
     border-radius: 6px;
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 1.2rem;
-    color: #ccc;
+    color: var(--text);
     flex-shrink: 0;
 }
 
 /* Server Stats Enhanced */
 .server-stats-container {
-    background: rgba(0, 0, 0, 0.2);
-    border: 1px solid rgba(255, 255, 255, 0.05);
+    background: var(--bg-transparent);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 12px;
     margin-bottom: 20px;
@@ -1329,7 +1371,7 @@ form button:hover { background:#45a049; }
     display: flex;
     align-items: center;
     gap: 6px;
-    color: #ccc;
+    color: var(--text);
     white-space: nowrap;
 }
 .stats-label {
@@ -1342,11 +1384,11 @@ form button:hover { background:#45a049; }
 }
 .stats-value {
     display: inline-block;
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: var(--bg-hover);
+    border: 1px solid var(--border);
     padding: 1px 6px;
     border-radius: 4px;
-    color: #fff;
+    color: var(--text);
     font-family: monospace, monospace;
     font-size: 0.85rem;
     font-weight: 600;
@@ -1358,7 +1400,7 @@ form button:hover { background:#45a049; }
     top: 10px;
     right: 10px;
     background: transparent;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--border);
     border-radius: 4px;
     color: var(--muted);
     cursor: pointer;
@@ -1403,9 +1445,9 @@ form button:hover { background:#45a049; }
 .branch-btn {
   flex: 1;
   padding: 10px 16px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--bg-hover);
   border: 1px solid var(--border);
-  color: #aaa;
+  color: var(--muted);
   font-weight: 600;
   border-radius: 6px;
   cursor: pointer;
@@ -1416,8 +1458,8 @@ form button:hover { background:#45a049; }
   gap: 8px;
 }
 .branch-btn:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: #fff;
+  filter: brightness(1.2);
+  color: var(--text);
 }
 .branch-btn.active {
   background: var(--accent);
@@ -1429,4 +1471,59 @@ form button:hover { background:#45a049; }
   background: #ff9800; /* Orange for Beta */
   border-color: #ff9800;
   box-shadow: 0 2px 8px rgba(255, 152, 0, 0.3);
+}
+
+/* Setup/Info Modals */
+.info-box {
+  background: rgba(33, 150, 243, 0.1);
+  border: 1px solid rgba(33, 150, 243, 0.3);
+  padding: 15px;
+  border-radius: 6px;
+  margin-bottom: 20px;
+}
+.info-label {
+  color: #64b5f6;
+  font-weight: bold;
+  margin-bottom: 8px;
+  display: block;
+}
+.info-text {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+.code-block {
+  background: #111;
+  padding: 10px;
+  border-radius: 4px;
+  border: 1px solid #333;
+  font-family: monospace;
+  font-size: 0.8rem;
+  word-break: break-all;
+  margin-bottom: 8px;
+  color: #eee;
+}
+.modal-description {
+  margin-bottom: 20px;
+  line-height: 1.6;
+  color: var(--text);
+}
+.modal-description ul {
+  list-style: disc;
+  margin-left: 20px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+.danger-box {
+  background: rgba(211, 47, 47, 0.1);
+  border: 1px solid rgba(211, 47, 47, 0.3);
+  padding: 15px;
+  border-radius: 6px;
+  margin-bottom: 20px;
+}
+.danger-label {
+  color: #e57373;
+  font-weight: bold;
+  margin-bottom: 8px;
+  display: block;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1434,7 +1434,6 @@ function showServerView() {
         document.getElementById('users-btn').style.display = '';
     }
 
-    document.getElementById('server-actions').classList.remove('visible');
     selectedServerId = null;
     window.scrollTo(0, 0);
 }
@@ -1592,7 +1591,6 @@ function showSessionsView(serverId, serverName, highlightUser = null) {
         document.getElementById('users-btn').style.display = 'none';
     }
 
-    document.getElementById('server-actions').classList.add('visible');
     window.scrollTo(0, 0);
 
     // Render sessions
@@ -1900,15 +1898,15 @@ async function showItemDetails(serverName, itemId, serverType) {
             }
 
             html += `
-                <div style="margin-top: 12px; padding: 12px; background: rgba(0,0,0,0.2); border-radius: 8px; font-family: monospace; font-size: 0.85rem; word-break: break-all; color: #aaa;">
+                <div class="modal-file-info">
                     <div style="margin-bottom: 8px;">
-                        <div style="font-size: 0.7rem; text-transform: uppercase; margin-bottom: 2px; color: #666;">Root Path</div>
-                        ${esc(dir)}
+                        <div class="modal-file-label">Root Path</div>
+                        <span class="modal-file-value">${esc(dir)}</span>
                     </div>
                     ${file ? `
                     <div>
-                        <div style="font-size: 0.7rem; text-transform: uppercase; margin-bottom: 2px; color: #666;">Filename</div>
-                        <span style="color: #aaa;">${esc(file)}</span>
+                        <div class="modal-file-label">Filename</div>
+                        <span class="modal-file-value">${esc(file)}</span>
                     </div>` : ''}
                 </div>
             `;
@@ -2524,10 +2522,10 @@ async function fetchAndRenderInlineLibraries(serverName) {
             `;
 
             data.libraries.forEach(lib => {
-                const countBadge = lib.count !== undefined ? `<span style="color:#aaa; font-size:0.75rem;">(${lib.count})</span>` : '';
+                const countBadge = lib.count !== undefined ? `<span style="color:var(--muted); font-size:0.75rem;">(${lib.count})</span>` : '';
                 html += `
-                    <div class="inline-library-item" style="background:rgba(255,255,255,0.08); border:1px solid rgba(255,255,255,0.1); border-radius:4px; padding:4px 8px; display:flex; align-items:center; gap:6px; font-size:0.85rem;">
-                        <span style="color:#eee;">${esc(lib.name)} ${countBadge}</span>
+                    <div class="inline-library-item">
+                        <span>${esc(lib.name)} ${countBadge}</span>
                         <button class="btn primary scan-lib-btn" style="padding:2px 6px; font-size:0.7rem; min-height:auto;" onclick="scanLibrary('${esc(serverName)}', '${esc(lib.id)}', '${esc(lib.name)}', this)" title="Scan Library">
                             <i class="fa-solid fa-arrows-rotate"></i>
                         </button>
@@ -2726,3 +2724,38 @@ async function fetchServerStats(serverId) {
         statsEl.innerHTML = `<div style="color:#d32f2f; font-size:0.8rem; padding:10px;">Connection Failed: ${esc(e.message)}</div>`;
     }
 }
+
+// Theme Toggle Logic
+function initTheme() {
+    const themeToggleBtn = document.getElementById('theme-toggle-btn');
+    if (!themeToggleBtn) return;
+
+    function updateThemeIcon(theme) {
+        const icon = themeToggleBtn.querySelector('i');
+        if (theme === 'light') {
+            icon.className = 'fa-solid fa-sun';
+            themeToggleBtn.title = 'Switch to Dark Mode';
+            icon.style.color = '#ffa726'; // Orange-ish sun
+        } else {
+            icon.className = 'fa-solid fa-moon';
+            themeToggleBtn.title = 'Switch to Light Mode';
+            icon.style.color = ''; // Reset
+        }
+    }
+
+    // Check saved theme or default
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    document.documentElement.setAttribute('data-theme', savedTheme);
+    updateThemeIcon(savedTheme);
+
+    themeToggleBtn.addEventListener('click', () => {
+        const currentTheme = document.documentElement.getAttribute('data-theme') || 'dark';
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', newTheme);
+        localStorage.setItem('theme', newTheme);
+        updateThemeIcon(newTheme);
+    });
+}
+
+// Initialize Theme
+initTheme();

--- a/index.php
+++ b/index.php
@@ -33,7 +33,9 @@ $isAdmin = isAdmin();
       MENU +
     </div>
     <div class="header-section right" id="header-clock-btn">
+      <button class="btn header-btn" id="theme-toggle-btn" title="Toggle Theme"><i class="fa-solid fa-moon"></i></button>
       <?php if ($isAdmin): ?>
+      <button class="btn header-btn" id="ssh-keys-nav-btn" title="SSH Key Manager"><i class="fa-solid fa-key"></i> <span class="btn-text">Keys</span></button>
       <button class="btn header-btn" id="logs-btn" title="View System Logs" onclick="window.open('view_logs.php', 'SystemLogs')"><i class="fa-solid fa-file-lines"></i> <span class="btn-text">Logs</span></button>
       <?php endif; ?>
       <button class="btn danger header-btn" onclick="window.location.href='logout.php'"><i class="fa-solid fa-right-from-bracket"></i> <span class="btn-text">Logout</span></button>
@@ -48,13 +50,8 @@ $isAdmin = isAdmin();
     </div>
     <div class="top-bar-right">
       <?php if ($isAdmin): ?>
-      <div class="server-actions" id="server-actions">
-        <button class="btn" id="edit-server-btn">Edit</button>
-        <button class="btn danger" id="delete-server-btn">Delete</button>
-      </div>
       <button class="btn" id="reorder-btn" title="Toggle Reorder Mode">Reorder</button>
       <button class="btn" id="users-btn" title="Manage Users">Users</button>
-      <button class="btn" id="ssh-keys-nav-btn" title="SSH Key Manager">SSH Keys</button>
       <?php endif; ?>
     </div>
   </div>
@@ -66,10 +63,10 @@ $isAdmin = isAdmin();
     <span class="modal-close" onclick="closeServerSetupModal()">&times;</span>
     <h2 style="margin-bottom: 20px;">Connect Server via SSH</h2>
 
-    <div style="background: rgba(33, 150, 243, 0.1); border: 1px solid rgba(33, 150, 243, 0.3); padding: 15px; border-radius: 6px; margin-bottom: 20px;">
-      <label style="color: #64b5f6; font-weight: bold; margin-bottom: 8px; display: block;">Setup Command</label>
-      <div style="font-size: 0.85rem; color: #ccc; margin-bottom: 8px;">Run this unified command on your <strong>Linux</strong> media server to install the agent and authorized key:</div>
-      <div style="background: #111; padding: 10px; border-radius: 4px; border: 1px solid #333; font-family: monospace; font-size: 0.8rem; word-break: break-all; margin-bottom: 8px; color: #eee;" id="setup-command-display">
+    <div class="info-box">
+      <label class="info-label">Setup Command</label>
+      <div class="info-text">Run this unified command on your <strong>Linux</strong> media server to install the agent and authorized key:</div>
+      <div class="code-block" id="setup-command-display">
         Loading command...
       </div>
       <button class="btn" onclick="copyToClipboard('setup-command-display', this)">Copy Command</button>
@@ -88,19 +85,19 @@ $isAdmin = isAdmin();
     <span class="modal-close" onclick="closeSSHConnectedModal()">&times;</span>
     <h2 style="margin-bottom: 20px; color: #81c784;"><i class="fa-solid fa-shield-halved"></i> Secure Connection Active</h2>
 
-    <div style="margin-bottom: 20px; line-height: 1.6; color: #ccc;">
-      <p style="margin-bottom: 10px;">This server is connected using a dedicated SSH key pair (<code>mediasvc</code> user). This method is secure because:</p>
-      <ul style="list-style: disc; margin-left: 20px; color: #aaa; font-size: 0.9rem;">
+    <div class="modal-description">
+      <p>This server is connected using a dedicated SSH key pair (<code>mediasvc</code> user). This method is secure because:</p>
+      <ul>
         <li>No passwords are stored or transmitted.</li>
         <li>The connection is restricted to specific commands (updates, restarts, stats) via <code>sudoers</code>.</li>
         <li>Interactive login for this user is disabled.</li>
       </ul>
     </div>
 
-    <div style="background: rgba(211, 47, 47, 0.1); border: 1px solid rgba(211, 47, 47, 0.3); padding: 15px; border-radius: 6px; margin-bottom: 20px;">
-      <label style="color: #e57373; font-weight: bold; margin-bottom: 8px; display: block;">Uninstall / Disconnect</label>
-      <div style="font-size: 0.85rem; color: #ccc; margin-bottom: 8px;">To remove the dashboard agent and revoke access, run this command on your server:</div>
-      <div style="background: #111; padding: 10px; border-radius: 4px; border: 1px solid #333; font-family: monospace; font-size: 0.8rem; word-break: break-all; margin-bottom: 8px; color: #eee;" id="uninstall-command-display">
+    <div class="danger-box">
+      <label class="danger-label">Uninstall / Disconnect</label>
+      <div class="info-text">To remove the dashboard agent and revoke access, run this command on your server:</div>
+      <div class="code-block" id="uninstall-command-display">
         Loading command...
       </div>
       <button class="btn" onclick="copyToClipboard('uninstall-command-display', this)">Copy Command</button>

--- a/view_logs.php
+++ b/view_logs.php
@@ -34,12 +34,14 @@ if (isset($_GET['fetch'])) {
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>System Logs - Media Dashboard</title>
+<link rel="icon" type="image/svg+xml" href="assets/img/favicon.svg">
+<link rel="stylesheet" href="assets/css/style.css?v=<?= time() ?>">
 <style>
-    body { margin: 0; background: #0f0f0f; color: #eee; font-family: monospace; overflow: hidden; }
+    body { font-family: monospace; overflow: hidden; background: var(--bg); color: var(--text); }
     .header {
         padding: 10px 20px;
-        background: #1b1b1b;
-        border-bottom: 1px solid #333;
+        background: var(--card);
+        border-bottom: 1px solid var(--border);
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -48,26 +50,12 @@ if (isset($_GET['fetch'])) {
     }
     .title { font-weight: bold; font-size: 1.1rem; }
     .controls { display: flex; gap: 15px; align-items: center; }
-    .btn {
-        background: #333;
-        color: #eee;
-        border: 1px solid #555;
-        padding: 5px 12px;
-        border-radius: 4px;
-        cursor: pointer;
-        font-size: 0.85rem;
-    }
-    .btn:hover { background: #444; }
-    .btn.active { background: #4caf50; border-color: #4caf50; color: white; }
+
+    /* Override inputs for logs specifically if needed, but inheriting style.css is better */
     input[type="text"], select {
-        background: #333;
-        color: #eee;
-        border: 1px solid #555;
         padding: 5px 8px;
-        border-radius: 4px;
-        font-size: 0.85rem;
     }
-    input[type="text"]:focus, select:focus { outline: none; border-color: #4caf50; }
+
     #log-container {
         padding: 20px;
         height: calc(100vh - 50px);
@@ -77,17 +65,31 @@ if (isset($_GET['fetch'])) {
         word-wrap: break-word;
         font-size: 0.9rem;
         line-height: 1.4;
-        color: #a5d6a7; /* Terminal green */
+        color: var(--text);
     }
     .log-line { margin-bottom: 2px; }
-    .log-line:hover { background: rgba(255,255,255,0.05); }
-    /* Syntax highlighting */
+    .log-line:hover { background: var(--bg-hover); }
+
+    /* Syntax highlighting - Theme Aware */
     .level-INFO { color: #81c784; }
+    [data-theme="light"] .level-INFO { color: #2e7d32; }
+
     .level-WARN { color: #ffb74d; }
+    [data-theme="light"] .level-WARN { color: #ef6c00; }
+
     .level-ERROR { color: #e57373; font-weight: bold; }
+    [data-theme="light"] .level-ERROR { color: #c62828; }
+
     .level-AUTH { color: #64b5f6; }
-    .timestamp { color: #666; margin-right: 10px; }
+    [data-theme="light"] .level-AUTH { color: #1565c0; }
+
+    .timestamp { color: var(--muted); margin-right: 10px; }
 </style>
+<script>
+    // Apply theme immediately
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    document.documentElement.setAttribute('data-theme', savedTheme);
+</script>
 </head>
 <body>
 


### PR DESCRIPTION
- Remove redundant Edit and Delete buttons from the top menu (now in server headers).
- Move SSH Keys button to the main header bar and rename to 'Keys'.
- Update `index.php` and `assets/js/main.js` to reflect structural changes and remove dead code.