### PR TITLE
Update Windows SSH setup instructions and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,13 @@ We provide a helper script to automate the secure setup process on Linux.
 You can install it via PowerShell:
 ```powershell
 dism /online /add-capability /capabilityname:OpenSSH.Server~~~~0.0.1.0
+
 Start-Service sshd
 Set-Service -Name sshd -StartupType 'Automatic'
+
+New-NetFirewallRule -Name "OpenSSH-Server-In-TCP" `
+  -DisplayName "OpenSSH Server (sshd)" `
+  -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
 ```
 
 1.  **Run the Unified Command:**
@@ -124,7 +129,8 @@ Set-Service -Name sshd -StartupType 'Automatic'
 
     *Run this in an Administrator PowerShell window on your media server:*
     ```powershell
-    Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://your-dashboard/os_helpers/windows_setup.ps1')); Install-User -Key "YOUR_PUBLIC_KEY"
+    Invoke-WebRequest https://your-dashboard/os_helpers/windows_setup.ps1 -OutFile windows_setup.ps1
+    .\windows_setup.ps1 -Install -Key 'ssh-rsa YOUR_PUBLIC_KEY'
     ```
 
 ### 4. Configure Remote Media Server (Manual Linux)

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -927,7 +927,7 @@ async function openServerSetupModal(serverId, serverName) {
             if (os === 'windows') {
                 const scriptUrl = `${baseUrl}/os_helpers/windows_setup.ps1`;
                 // PowerShell Command
-                cmd = `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('${scriptUrl}')); Install-User -Key "${data.key}"`;
+                cmd = `Invoke-WebRequest "${scriptUrl}" -OutFile windows_setup.ps1\n.\\windows_setup.ps1 -Install -Key "${data.key}"`;
             } else {
                 // Linux Command
                 const scriptUrl = `${baseUrl}/os_helpers/linux_setup.sh`;


### PR DESCRIPTION
Updated the Windows SSH setup instructions in README.md and the generated setup command in the dashboard UI. The new command uses `Invoke-WebRequest` to download the setup script to a file and then executes it, as requested. Also added firewall rule and service start instructions to the documentation. Verified frontend changes with Playwright.

---
*PR created automatically by Jules for task [15964788201090380256](https://jules.google.com/task/15964788201090380256) started by @Tophicles*