### PR TITLE
Mask API Key and Token fields as password type

### DIFF
--- a/index.php
+++ b/index.php
@@ -242,11 +242,11 @@ $isAdmin = isAdmin();
         </div>
         <div class="server-form-group" id="group-apikey">
           <label>API Key (Emby/Jellyfin)</label>
-          <input type="text" name="apiKey">
+          <input type="password" name="apiKey">
         </div>
         <div class="server-form-group" id="group-token">
           <label>Token (Plex)</label>
-          <input type="text" name="token">
+          <input type="password" name="token">
         </div>
 
         <!-- OS Configuration -->


### PR DESCRIPTION
Changed `input type="text"` to `input type="password"` for both API Key and Token fields in `index.php`. This masks the input characters in the "Add Server" and "Edit Server" modal. Confirmed that the inputs are masked and visibility toggles correctly between Emby (API Key) and Plex (Token) modes.

---
*PR created automatically by Jules for task [7487553480345612316](https://jules.google.com/task/7487553480345612316) started by @Tophicles*