### PR TITLE
Fix Docker permissions and PHP 8.1 warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,14 @@ ENV CONFIG_DIR=/config
 # Copy application files
 COPY . /var/www/html/
 
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # Set correct permissions
 RUN chown -R www-data:www-data /var/www/html
 
-# Drop privileges explicitly
-USER www-data
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2-foreground"]
 
 EXPOSE 80

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Fix permissions for config directory if it exists
+if [ -d "/config" ]; then
+    chown -R www-data:www-data /config
+fi
+
+# Execute the original entrypoint logic
+exec docker-php-entrypoint "$@"

--- a/get_item_details.php
+++ b/get_item_details.php
@@ -133,7 +133,7 @@ try {
             'overview' => $data['Overview'] ?? '',
             'year' => $data['ProductionYear'] ?? '',
             'rating' => isset($data['CommunityRating']) ? number_format($data['CommunityRating'], 1) : '',
-            'runtime' => isset($data['RunTimeTicks']) ? formatRuntime($data['RunTimeTicks'] / 10000000 / 60) : '',
+            'runtime' => isset($data['RunTimeTicks']) ? formatRuntime((float)$data['RunTimeTicks'] / 10000000 / 60) : '',
             'genres' => '',
             'director' => '',
             'studio' => '',
@@ -254,7 +254,7 @@ try {
             'overview' => $metadata['summary'] ?? '',
             'year' => $metadata['year'] ?? '',
             'rating' => isset($metadata['rating']) ? number_format($metadata['rating'], 1) : '',
-            'runtime' => isset($metadata['duration']) ? formatRuntime($metadata['duration'] / 1000 / 60) : '',
+            'runtime' => isset($metadata['duration']) ? formatRuntime((float)$metadata['duration'] / 1000 / 60) : '',
             'genres' => '',
             'director' => '',
             'studio' => $metadata['studio'] ?? '',
@@ -325,6 +325,7 @@ try {
 }
 
 function formatRuntime($minutes) {
+    if (!is_numeric($minutes)) return '';
     $hours = floor($minutes / 60);
     $mins = round($minutes % 60);
     if ($hours > 0) {

--- a/path_helper.php
+++ b/path_helper.php
@@ -20,9 +20,17 @@ if (!defined('DB_DIR')) {
 // Ensure DB directory exists
 if (!file_exists(DB_DIR)) {
     if (!file_exists(DATA_DIR)) {
-        mkdir(DATA_DIR, 0777, true);
+        if (!@mkdir(DATA_DIR, 0777, true)) {
+            $error = error_get_last();
+            die("Error: Cannot create data directory " . DATA_DIR . ". " . ($error['message'] ?? 'Permission denied.'));
+        }
     }
-    mkdir(DB_DIR, 0777, true);
+    if (!file_exists(DB_DIR)) {
+        if (!@mkdir(DB_DIR, 0777, true)) {
+            $error = error_get_last();
+            die("Error: Cannot create database directory " . DB_DIR . ". " . ($error['message'] ?? 'Permission denied.'));
+        }
+    }
 
     // Migration: Move existing JSON files to DB_DIR
     $filesToMove = ['users.json', 'servers.json', 'activity.json', 'watcher_state.json'];


### PR DESCRIPTION
- Add `docker-entrypoint.sh` to fix permissions on `/config`.
- Update `Dockerfile` to use the entrypoint and run as root.
- Update `path_helper.php` to prevent fatal errors when directories already exist.
- Update `get_item_details.php` to cast inputs to float before division to avoid deprecation warnings.