### PR TITLE
Fix PHP Deprecation Warnings in API Endpoints

### DIFF
--- a/add_server.php
+++ b/add_server.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 require_once 'encryption_helper.php';
 require_once 'logging.php';

--- a/backup.php
+++ b/backup.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 require_once 'logging.php';
 require_once 'path_helper.php';

--- a/delete_server.php
+++ b/delete_server.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 require_once 'logging.php';
 requireLogin();

--- a/get_active_users.php
+++ b/get_active_users.php
@@ -1,5 +1,6 @@
 <?php
 // Disable display_errors to ensure JSON output is not corrupted by warnings
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('display_errors', 0);
 
 require_once 'auth.php';

--- a/get_config.php
+++ b/get_config.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 require_once 'encryption_helper.php';
 require_once 'config_helper.php';

--- a/get_image.php
+++ b/get_image.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 require_once 'encryption_helper.php';
 requireLogin();

--- a/get_user.php
+++ b/get_user.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 requireLogin();
 

--- a/library_actions.php
+++ b/library_actions.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 require_once 'encryption_helper.php';
 require_once 'logging.php';

--- a/manage_users.php
+++ b/manage_users.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 require_once 'logging.php';
 requireLogin();

--- a/proxy.php
+++ b/proxy.php
@@ -1,5 +1,6 @@
 <?php
 // Disable display_errors to ensure JSON output is not corrupted by warnings
+error_reporting(E_ALL & ~E_DEPRECATED);
 ini_set('display_errors', 0);
 
 require_once 'auth.php';

--- a/ssh_manager.php
+++ b/ssh_manager.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 require_once 'logging.php';
 require_once 'ssh_helper.php';

--- a/update_order.php
+++ b/update_order.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 requireLogin();
 requireAdmin();

--- a/update_server.php
+++ b/update_server.php
@@ -1,4 +1,6 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
 require_once 'auth.php';
 require_once 'encryption_helper.php';
 require_once 'logging.php';


### PR DESCRIPTION
Suppress deprecation warnings in API endpoints to prevent JSON/Image corruption.

---
*PR created automatically by Jules for task [5961886074169685265](https://jules.google.com/task/5961886074169685265) started by @Tophicles*