### PR TITLE
Fix 500 error in get_config.php due to Docker permission issues

### DIFF
--- a/encryption_helper.php
+++ b/encryption_helper.php
@@ -11,10 +11,30 @@ function getSecretKey() {
         // Generate a random 32-byte key and store it as a hex string in a PHP file
         $key = bin2hex(random_bytes(32));
         $content = "<?php\n// This file was automatically generated for sensitive data encryption.\n// DO NOT share this file.\nreturn '$key';\n";
-        file_put_contents($keyFile, $content);
+
+        $result = @file_put_contents($keyFile, $content);
+        if ($result === false) {
+            error_log("Encryption Helper: Failed to write key file to $keyFile");
+            http_response_code(500);
+            if (!headers_sent()) {
+                header('Content-Type: application/json');
+            }
+            die(json_encode(['error' => 'Internal Server Error: Unable to write security key to ' . $keyFile . '. Check directory permissions.']));
+        }
+
         // Set restrictive permissions if possible
         @chmod($keyFile, 0600);
     }
+
+    if (!file_exists($keyFile)) {
+         error_log("Encryption Helper: Key file missing at $keyFile");
+         http_response_code(500);
+         if (!headers_sent()) {
+             header('Content-Type: application/json');
+         }
+         die(json_encode(['error' => 'Internal Server Error: Security key file is missing.']));
+    }
+
     return require $keyFile;
 }
 

--- a/path_helper.php
+++ b/path_helper.php
@@ -17,19 +17,28 @@ if (!defined('DB_DIR')) {
     define('DB_DIR', DATA_DIR . 'db/');
 }
 
-// Ensure DB directory exists
-if (!file_exists(DB_DIR)) {
-    if (!file_exists(DATA_DIR)) {
-        if (!@mkdir(DATA_DIR, 0777, true)) {
-            $error = error_get_last();
-            die("Error: Cannot create data directory " . DATA_DIR . ". " . ($error['message'] ?? 'Permission denied.'));
-        }
+// Ensure DATA_DIR exists
+if (!file_exists(DATA_DIR)) {
+    if (!@mkdir(DATA_DIR, 0777, true)) {
+        $error = error_get_last();
+        die("Error: Cannot create data directory " . DATA_DIR . ". " . ($error['message'] ?? 'Permission denied.'));
     }
-    if (!file_exists(DB_DIR)) {
-        if (!@mkdir(DB_DIR, 0777, true)) {
-            $error = error_get_last();
-            die("Error: Cannot create database directory " . DB_DIR . ". " . ($error['message'] ?? 'Permission denied.'));
-        }
+}
+
+// Ensure DATA_DIR is writable
+if (!is_writable(DATA_DIR)) {
+    // Attempt to fix permissions
+    if (!@chmod(DATA_DIR, 0777)) {
+        http_response_code(500);
+        die("Error: Data directory " . DATA_DIR . " is not writable. Please check file permissions.");
+    }
+}
+
+// Ensure DB_DIR exists
+if (!file_exists(DB_DIR)) {
+    if (!@mkdir(DB_DIR, 0777, true)) {
+        $error = error_get_last();
+        die("Error: Cannot create database directory " . DB_DIR . ". " . ($error['message'] ?? 'Permission denied.'));
     }
 
     // Migration: Move existing JSON files to DB_DIR
@@ -38,6 +47,15 @@ if (!file_exists(DB_DIR)) {
         if (file_exists(DATA_DIR . $file)) {
             rename(DATA_DIR . $file, DB_DIR . $file);
         }
+    }
+}
+
+// Ensure DB_DIR is writable
+if (!is_writable(DB_DIR)) {
+    // Attempt to fix permissions
+    if (!@chmod(DB_DIR, 0777)) {
+        http_response_code(500);
+        die("Error: Database directory " . DB_DIR . " is not writable. Please check file permissions.");
     }
 }
 ?>


### PR DESCRIPTION
Fixed an issue where `get_config.php` would crash with a 500 error and empty response body if the application could not write the secret key file or create data directories, common in Docker environments with volume permission mismatches.

Changes:
- `path_helper.php`: Added explicit checks for `DATA_DIR` and `DB_DIR` writability. Attempts to `chmod` to 0777 if not writable, and `die`s with a clear error message if that fails. Also refactored to verify parent `DATA_DIR` before creating child `DB_DIR`.
- `encryption_helper.php`: Wrapped `file_put_contents` for `key.php` in a check. If writing fails, it now returns a structured JSON 500 error instead of letting the subsequent `require` statement cause a fatal PHP error. Added a check for file existence before `require`.

---
*PR created automatically by Jules for task [6467130193693014763](https://jules.google.com/task/6467130193693014763) started by @Tophicles*