### PR TITLE
feat: add PUID/PGID support for Unraid compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     libzip-dev \
     zip \
     unzip \
+    passwd \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHP extensions

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 set -e
 
+# Handle PUID/PGID if provided (e.g. for Unraid)
+if [ -n "$PUID" ] && [ -n "$PGID" ]; then
+    echo "Updating www-data to UID: $PUID, GID: $PGID"
+
+    # Update group ID
+    groupmod -o -g "$PGID" www-data || echo "Warning: Failed to update GID"
+
+    # Update user ID
+    usermod -o -u "$PUID" -g www-data www-data || echo "Warning: Failed to update UID"
+
+    # Ensure proper ownership of web root
+    if [ -d "/var/www/html" ]; then
+        chown -R www-data:www-data /var/www/html
+    fi
+fi
+
 # Fix permissions for config directory if it exists
 if [ -d "/config" ]; then
     chown -R www-data:www-data /config


### PR DESCRIPTION
This PR updates the Docker deployment files to support the `PUID` and `PGID` environment variables, which are commonly used in Unraid and other home server environments to manage file permissions.

Previously, the container ran as the default `www-data` user (UID 33), which caused permission conflicts when mounting volumes on Unraid (where user files are typically owned by UID 99). This would lead to the container failing to start or being unable to access configuration files ("WebUI will not load").

The changes include:
1.  Installing the `passwd` package in the Dockerfile to ensure `usermod` and `groupmod` are available.
2.  Updating `docker-entrypoint.sh` to dynamically update the `www-data` UID/GID if `PUID` and `PGID` are provided.
3.  Ensuring proper ownership of the application and config directories.

This makes the provided Unraid XML template valid and functional.

---
*PR created automatically by Jules for task [4013326895465589552](https://jules.google.com/task/4013326895465589552) started by @Tophicles*