### PR TITLE
Add show title and episode info to user detail view

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1578,7 +1578,11 @@ function openMediaUserModal(u) {
                 <div class="active-session-top">
                     <div class="history-item-details">
                         <div class="history-item-title">${esc(activeSession.title)}</div>
-                        <div class="history-item-meta">${activeSession.progress || '0'}% complete</div>
+                        ${activeSession.series ? `<div class="history-item-subtitle" style="font-size: 0.85rem; color: var(--muted);">${esc(activeSession.series)}</div>` : ''}
+                        <div class="history-item-meta">
+                            ${(activeSession.season !== undefined && activeSession.season !== null && activeSession.episode !== undefined && activeSession.episode !== null) ? `S${String(activeSession.season).padStart(2, '0')}E${String(activeSession.episode).padStart(2, '0')} • ` : ''}
+                            ${activeSession.progress || '0'}% complete
+                        </div>
                     </div>
                     <button class="btn primary" id="user-modal-jump-btn">
                         <i class="fa-solid fa-external-link-alt"></i> Jump to Server
@@ -1699,11 +1703,18 @@ function renderMediaUserHistory(history, append = false, u = null) {
 
         const itemEl = document.createElement('div');
         itemEl.className = 'history-item';
+
+        let epInfo = '';
+        if (item.season !== undefined && item.season !== null && item.episode !== undefined && item.episode !== null) {
+            epInfo = `S${String(item.season).padStart(2, '0')}E${String(item.episode).padStart(2, '0')} • `;
+        }
+
         itemEl.innerHTML = `
             <img src="${esc(item.image)}" class="history-item-image" onerror="this.src='assets/img/favicon.svg';">
             <div class="history-item-details">
                 <div class="history-item-title">${esc(item.title)}</div>
-                <div class="history-item-meta">${esc(item.type)} • ${dateStr}</div>
+                ${item.series ? `<div class="history-item-subtitle" style="font-size: 0.85rem; color: var(--muted);">${esc(item.series)}</div>` : ''}
+                <div class="history-item-meta">${epInfo}${esc(item.type)} • ${dateStr}</div>
             </div>
         `;
         listContainer.appendChild(itemEl);

--- a/get_media_user_details.php
+++ b/get_media_user_details.php
@@ -83,7 +83,7 @@ if ($type === 'emby' || $type === 'jellyfin') {
 
     // 2. Get Watch History
     // Added UserData to fields and EnableUserData=true to ensure dates are returned
-    $url = "$baseUrl/Users/$userId/Items?Recursive=true&IncludeItemTypes=Movie,Episode&SortBy=DatePlayed&SortOrder=Descending&Filters=IsPlayed&StartIndex=$offset&Limit=$limit&Fields=PrimaryImageAspectRatio,DateCreated,LastPlayedDate,DateLastPlayed,UserData,DatePlayed,PlayedDate&EnableUserData=true";
+    $url = "$baseUrl/Users/$userId/Items?Recursive=true&IncludeItemTypes=Movie,Episode&SortBy=DatePlayed&SortOrder=Descending&Filters=IsPlayed&StartIndex=$offset&Limit=$limit&Fields=PrimaryImageAspectRatio,DateCreated,LastPlayedDate,DateLastPlayed,UserData,DatePlayed,PlayedDate,SeriesName,ParentIndexNumber,IndexNumber&EnableUserData=true";
     $ch = curl_init($url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_TIMEOUT, 5);
@@ -102,15 +102,14 @@ if ($type === 'emby' || $type === 'jellyfin') {
         }
         $items = $data['Items'] ?? [];
         foreach ($items as $item) {
-            $title = $item['Name'] ?? 'Unknown';
-            if (isset($item['SeriesName'])) {
-                $title = $item['SeriesName'] . ' - ' . $title;
-            }
             // Check UserData first, then top level, then other potential date fields
             $playedDate = $item['UserData']['LastPlayedDate'] ?? $item['LastPlayedDate'] ?? $item['DateLastPlayed'] ?? $item['DatePlayed'] ?? $item['PlayedDate'] ?? $item['PremiereDate'] ?? $item['DateCreated'] ?? null;
             $response['history'][] = [
                 'id' => $item['Id'],
-                'title' => $title,
+                'title' => $item['Name'] ?? 'Unknown',
+                'series' => $item['SeriesName'] ?? null,
+                'season' => $item['ParentIndexNumber'] ?? null,
+                'episode' => $item['IndexNumber'] ?? null,
                 'type' => $item['Type'],
                 'date' => $playedDate,
                 'image' => "get_image.php?serverId=$serverId&serverType=$type&id=" . ($item['Id']) . "&type=Primary"
@@ -143,11 +142,6 @@ if ($type === 'emby' || $type === 'jellyfin') {
         }
         $metadata = $data['MediaContainer']['Metadata'] ?? [];
         foreach ($metadata as $item) {
-            $title = $item['title'] ?? 'Unknown';
-            if (isset($item['grandparentTitle'])) {
-                $title = $item['grandparentTitle'] . ' - ' . $title;
-            }
-
             $imgId = $item['ratingKey'] ?? '';
             if (isset($item['grandparentRatingKey'])) {
                 $imgId = $item['grandparentRatingKey'];
@@ -156,7 +150,10 @@ if ($type === 'emby' || $type === 'jellyfin') {
             $viewedAt = $item['viewedAt'] ?? $item['lastViewedAt'] ?? null;
             $response['history'][] = [
                 'id' => $item['ratingKey'],
-                'title' => $title,
+                'title' => $item['title'] ?? 'Unknown',
+                'series' => $item['grandparentTitle'] ?? null,
+                'season' => $item['parentIndex'] ?? null,
+                'episode' => $item['index'] ?? null,
                 'type' => $item['type'],
                 'date' => $viewedAt ? date('c', (int)$viewedAt) : null,
                 'image' => "get_image.php?serverId=$serverId&serverType=$type&id=$imgId&type=thumb"


### PR DESCRIPTION
This change enhances the Media User Modal by including the show title and formatted season/episode information (e.g., S01E05) for TV shows. 

Key changes:
- **Backend (`get_media_user_details.php`)**: Now extracts `series`, `season`, and `episode` from media server API responses. For Emby/Jellyfin, it uses `SeriesName`, `ParentIndexNumber`, and `IndexNumber`. For Plex, it uses `grandparentTitle`, `parentIndex`, and `index`.
- **Frontend (`assets/js/main.js`)**: The `openMediaUserModal` and `renderMediaUserHistory` functions were updated to use the new metadata. The series name is displayed as a subtle subtitle, and the season/episode info is included in the metadata line.
- **Robustness**: The frontend logic uses explicit checks for `null` and `undefined` when handling season/episode numbers to ensure that "Season 0" (commonly used for specials) is displayed correctly and not ignored as a falsy value.

---
*PR created automatically by Jules for task [6321345214364357201](https://jules.google.com/task/6321345214364357201) started by @Tophicles*