### PR TITLE
Rename Manage Users to MultiDash Users

### DIFF
--- a/index.php
+++ b/index.php
@@ -58,7 +58,7 @@ $isAdmin = isAdmin();
             <i class="fa-solid fa-sort"></i> <span>Reorder Servers</span>
           </div>
           <div class="menu-item" id="users-btn">
-            <i class="fa-solid fa-users"></i> <span>Manage Users</span>
+            <i class="fa-solid fa-users"></i> <span>MultiDash Users</span>
           </div>
           <div class="menu-item" id="ssh-keys-nav-btn">
             <i class="fa-solid fa-key"></i> <span>SSH Keys</span>
@@ -407,7 +407,7 @@ $isAdmin = isAdmin();
   <div class="modal-content">
     <span class="modal-close" onclick="closeUsersModal()">&times;</span>
     <div id="users-modal-body">
-      <h2 style="margin-bottom: 20px;">User Management</h2>
+      <h2 style="margin-bottom: 20px;">MultiDash Users</h2>
       
       <!-- Add User Form -->
       <div class="user-form-container">


### PR DESCRIPTION
The "Manage Users" menu item and its corresponding modal title have been renamed to "MultiDash Users" to avoid confusion with the newly added "Media Users" button. This change improves UI clarity by explicitly labeling the dashboard-specific user management interface. Visual verification was performed using Playwright to ensure the labels are correctly displayed in both the menu and the modal.

---
*PR created automatically by Jules for task [14521139413773915972](https://jules.google.com/task/14521139413773915972) started by @Tophicles*