### PR TITLE
Fix SSH Key Writing and Execution in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     libzip-dev \
     zip \
     unzip \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PHP extensions

--- a/ssh_helper.php
+++ b/ssh_helper.php
@@ -30,8 +30,14 @@ function generateSSHKeyPair() {
     if (file_exists(SSH_PRIVATE_KEY_PATH)) unlink(SSH_PRIVATE_KEY_PATH);
     if (file_exists(SSH_PUBLIC_KEY_PATH)) unlink(SSH_PUBLIC_KEY_PATH);
 
-    $cmd = "ssh-keygen -t rsa -b 4096 -C \"multidash\" -f " . escapeshellarg(SSH_PRIVATE_KEY_PATH) . " -N \"\" -q";
+    // Set HOME=/tmp to ensure ssh-keygen can write temporary files if needed
+    // even if the web user doesn't have a writable home directory.
+    $cmd = "env HOME=/tmp ssh-keygen -t rsa -b 4096 -C \"multidash\" -f " . escapeshellarg(SSH_PRIVATE_KEY_PATH) . " -N \"\" -q 2>&1";
     exec($cmd, $output, $returnVar);
+
+    if ($returnVar !== 0) {
+        writeLog("SSH Key Generation Failed: " . implode("\n", $output), "ERROR");
+    }
 
     // Set correct permissions for private key (essential for SSH)
     if (file_exists(SSH_PRIVATE_KEY_PATH)) {
@@ -54,8 +60,9 @@ function executeSSHCommand($host, $port, $user, $command, $timeout = 10) {
     // -o BatchMode=yes: Don't ask for passwords
 
     // Use `timeout` command to prevent execution hang
+    // Set HOME=/tmp to ensure ssh can access a writable directory for temporary files
     $sshCmd = sprintf(
-        "timeout %d ssh -i %s -p %d -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=5 -o BatchMode=yes %s@%s %s 2>&1",
+        "env HOME=/tmp timeout %d ssh -i %s -p %d -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=5 -o BatchMode=yes %s@%s %s 2>&1",
         (int)$timeout,
         escapeshellarg(SSH_PRIVATE_KEY_PATH),
         (int)$port,


### PR DESCRIPTION
The Docker container was failing to write SSH keys because of missing `openssh-client` and potential home directory permission issues for the `www-data` user. I've updated the `Dockerfile` to include the necessary package and modified `ssh_helper.php` to use `/tmp` as a temporary home for SSH commands, ensuring they have a writable location for temporary files. I also added better error logging for SSH key generation.

---
*PR created automatically by Jules for task [12972935431490583611](https://jules.google.com/task/12972935431490583611) started by @Tophicles*