### PR TITLE
Unique SSH Usernames per MultiDash Instance

### DIFF
--- a/add_server.php
+++ b/add_server.php
@@ -67,6 +67,7 @@ if (!empty($data['token'])) {
 // Add OS/SSH fields
 $newServer['os_type'] = $data['os_type'] ?? 'linux';
 if (!empty($data['ssh_port'])) $newServer['ssh_port'] = $data['ssh_port'];
+$newServer['ssh_user'] = $data['ssh_user'] ?? 'mediasvc';
 
 $config['servers'][] = $newServer;
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -93,6 +93,7 @@ function showModalConfirm(message, title = 'Confirm Action') {
 }
 
 let SERVERS = [];
+let SUGGESTED_SSH_USER = 'mediasvc';
 let ALL_SESSIONS = {};
 let refreshTimer = null;
 let currentView = 'servers'; // 'servers', 'sessions', or 'all'
@@ -109,6 +110,7 @@ function updateServerFormFields() {
     const urlInput = document.getElementById('server-url-input');
     const osSelect = document.getElementById('server-os-select');
     const sshPortGroup = document.getElementById('ssh-port-group');
+    const sshUserGroup = document.getElementById('ssh-user-group');
 
     if (!typeSelect || !apiKeyGroup || !tokenGroup) return;
 
@@ -128,11 +130,13 @@ function updateServerFormFields() {
     }
 
     // OS Logic
-    if (osSelect && sshPortGroup) {
+    if (osSelect && sshPortGroup && sshUserGroup) {
         if (osSelect.value === 'linux') {
             sshPortGroup.style.display = 'flex';
+            sshUserGroup.style.display = 'flex';
         } else {
             sshPortGroup.style.display = 'none';
+            sshUserGroup.style.display = 'none';
         }
     }
 }
@@ -175,6 +179,9 @@ function openServerModal(isEdit = false) {
         btn.textContent = 'Add Server';
         form.reset();
         delete form.dataset.originalName;
+        // Prepopulate SSH user
+        const sshUserInput = form.querySelector('[name="ssh_user"]');
+        if (sshUserInput) sshUserInput.value = SUGGESTED_SSH_USER;
         // Reset visibility for new form
         updateServerFormFields();
     }
@@ -502,6 +509,7 @@ async function loadConfig() {
         // Then sort by order
         return (a.order||0) - (b.order||0);
     });
+    SUGGESTED_SSH_USER = config.suggestedSSHUser || 'mediasvc';
     return config.refreshSeconds || 5;
 }
 
@@ -960,7 +968,8 @@ async function openServerSetupModal(serverId, serverName) {
 
             // Linux Command
             const scriptUrl = `${baseUrl}/os_helpers/linux_setup.sh`;
-            cmd = `wget -qO- "${scriptUrl}" | sudo bash -s install "${data.key}"`;
+            const sshUser = server ? (server.ssh_user || 'mediasvc') : 'mediasvc';
+            cmd = `wget -qO- "${scriptUrl}" | sudo bash -s install "${data.key}" "${sshUser}"`;
 
             cmdDisplay.innerText = cmd;
             verifyBtn.disabled = false;
@@ -991,7 +1000,8 @@ function openSSHConnectedModal(serverId, serverName) {
 
     // Linux Command
     const scriptUrl = `${baseUrl}/os_helpers/linux_setup.sh`;
-    cmd = `wget -qO- "${scriptUrl}" | sudo bash -s uninstall`;
+    const sshUser = server ? (server.ssh_user || 'mediasvc') : 'mediasvc';
+    cmd = `wget -qO- "${scriptUrl}" | sudo bash -s uninstall "${sshUser}"`;
 
     cmdDisplay.innerText = cmd;
     modal.classList.add('visible');
@@ -2725,6 +2735,7 @@ function openEditServerModal(serverId) {
 
     form.querySelector('[name="os_type"]').value = server.os_type || 'linux';
     form.querySelector('[name="ssh_port"]').value = server.ssh_port || '22';
+    form.querySelector('[name="ssh_user"]').value = server.ssh_user || 'mediasvc';
 
     // Store server ID for update
     form.dataset.originalName = server.id;
@@ -2806,7 +2817,8 @@ document.getElementById('add-server-form').addEventListener('submit', async e=>{
         apiKey:f.apiKey.value,
         token:f.token.value,
         os_type: f.os_type.value,
-        ssh_port: f.ssh_port.value
+        ssh_port: f.ssh_port.value,
+        ssh_user: f.ssh_user.value
     };
 
     // If editing, include server ID

--- a/get_config.php
+++ b/get_config.php
@@ -28,6 +28,9 @@ if (validateAndMigrateConfig($config)) {
 
 $isAdmin = isAdmin();
 
+// Generate a unique suggested SSH user for this instance
+$config['suggestedSSHUser'] = 'media_' . substr(hash('sha256', getSecretKey()), 0, 6);
+
 if (isset($config['servers']) && is_array($config['servers'])) {
     foreach ($config['servers'] as &$server) {
         if ($isAdmin) {

--- a/index.php
+++ b/index.php
@@ -357,6 +357,11 @@ $isAdmin = isAdmin();
                 <label>SSH Port (Linux Only)</label>
                 <input type="number" name="ssh_port" value="22" placeholder="22">
             </div>
+
+            <div class="server-form-group" id="ssh-user-group">
+                <label>SSH Username (Linux Only)</label>
+                <input type="text" name="ssh_user" value="mediasvc" placeholder="mediasvc">
+            </div>
         </div>
 
         <div class="server-form-group" style="margin-top: 10px;">

--- a/os_helpers/linux_setup.sh
+++ b/os_helpers/linux_setup.sh
@@ -12,6 +12,12 @@ SSHD_CONFIG="/etc/ssh/sshd_config"
 MARKER_START="# BEGIN MEDIASVC-MULTIDASH"
 MARKER_END="# END MEDIASVC-MULTIDASH"
 
+update_vars() {
+    SUDOERS_FILE="/etc/sudoers.d/$USER_NAME"
+    MARKER_START="# BEGIN MEDIASVC-MULTIDASH-$USER_NAME"
+    MARKER_END="# END MEDIASVC-MULTIDASH-$USER_NAME"
+}
+
 ########################################
 # Root check
 ########################################
@@ -117,7 +123,13 @@ install_user() {
     echo "Configuring SSH key..."
     SSH_DIR="/home/$USER_NAME/.ssh"
     mkdir -p "$SSH_DIR"
-    echo "$PUB_KEY" > "$SSH_DIR/authorized_keys"
+    if [ -f "$SSH_DIR/authorized_keys" ]; then
+        if ! grep -qxF "$PUB_KEY" "$SSH_DIR/authorized_keys"; then
+            echo "$PUB_KEY" >> "$SSH_DIR/authorized_keys"
+        fi
+    else
+        echo "$PUB_KEY" > "$SSH_DIR/authorized_keys"
+    fi
     chown -R "$USER_NAME:$USER_NAME" "$SSH_DIR"
     chmod 700 "$SSH_DIR"
     chmod 600 "$SSH_DIR/authorized_keys"
@@ -126,6 +138,8 @@ install_user() {
     generate_sudoers
 
     echo "Locking down SSH..."
+    # Clean up legacy markers and current user markers
+    sed -i "/# BEGIN MEDIASVC-MULTIDASH/,/# END MEDIASVC-MULTIDASH/d" "$SSHD_CONFIG"
     sed -i "/$MARKER_START/,/$MARKER_END/d" "$SSHD_CONFIG"
 
     cat >> "$SSHD_CONFIG" <<EOF
@@ -162,8 +176,16 @@ uninstall_user() {
 # Main
 ########################################
 case "${1:-}" in
-    install) install_user "$@" ;;
-    uninstall) uninstall_user ;;
+    install)
+        USER_NAME="${3:-mediasvc}"
+        update_vars
+        install_user "$@"
+        ;;
+    uninstall)
+        USER_NAME="${2:-mediasvc}"
+        update_vars
+        uninstall_user
+        ;;
     *)
         echo "Usage: sudo ./linux_setup.sh [install|uninstall]"
         read -p "Choice [1] INSTALL USER or [2] REMOVE USER: " c

--- a/proxy.php
+++ b/proxy.php
@@ -55,7 +55,7 @@ if (in_array($action, ['ssh_restart', 'ssh_stop', 'ssh_start', 'ssh_status', 'ss
 
     // Settings
     $port = $server['ssh_port'] ?: 22;
-    $user = 'mediasvc';
+    $user = $server['ssh_user'] ?: 'mediasvc';
 
     // Determine Service Name based on Type and OS
     $service = '';
@@ -105,13 +105,13 @@ if (in_array($action, ['ssh_restart', 'ssh_stop', 'ssh_start', 'ssh_status', 'ss
     $timeout = 10;
 
     if ($action === 'ssh_update') {
-        $logFile = "/home/mediasvc/multidash_update_{$server['id']}.log";
+        $logFile = "/home/$user/multidash_update_{$server['id']}.log";
 
         // Check allowed sudo paths for update file
         $sudoCheckCmd = "sudo -l";
         $sudoCheckRes = executeSSHCommand($host, $port, $user, $sudoCheckCmd, 5);
 
-        $tmpDeb = "/home/mediasvc/multidash_update.deb"; // Default secure path
+        $tmpDeb = "/home/$user/multidash_update.deb"; // Default secure path
 
         if ($sudoCheckRes['success']) {
              if (strpos($sudoCheckRes['output'], '/tmp/multidash_update.deb') !== false) {
@@ -190,7 +190,7 @@ if (in_array($action, ['ssh_restart', 'ssh_stop', 'ssh_start', 'ssh_status', 'ss
                " > /dev/null 2>&1 &";
 
     } elseif ($action === 'ssh_update_log') {
-        $logFile = "/home/mediasvc/multidash_update_{$server['id']}.log";
+        $logFile = "/home/$user/multidash_update_{$server['id']}.log";
         // Check if file exists first to avoid error spam
         $cmd = "if [ -f $logFile ]; then cat $logFile; else echo \"Waiting for log...\"; fi";
     }

--- a/update_server.php
+++ b/update_server.php
@@ -38,7 +38,7 @@ if($serverIndex === null) {
 $existingServer = $servers['servers'][$serverIndex];
 
 // Fields to update if present in $data, otherwise keep existing
-$updatableFields = ['name', 'type', 'url', 'os_type', 'ssh_port', 'order', 'enabled', 'ssh_initialized'];
+$updatableFields = ['name', 'type', 'url', 'os_type', 'ssh_port', 'ssh_user', 'order', 'enabled', 'ssh_initialized'];
 
 foreach ($updatableFields as $field) {
     if (isset($data[$field])) {


### PR DESCRIPTION
This change addresses the issue where multiple MultiDash instances using the default "mediasvc" username would lock each other out when connecting to the same media server. 

Each MultiDash instance now generates a unique suggested SSH username (e.g., `media_a1b2c3`) based on its internal encryption key. This ensures isolation between different instances. Within a single instance, the same unique username is suggested for all managed servers by default, but it can be customized per-server if needed.

The Linux setup script has also been improved to append SSH keys to `authorized_keys` and use unique markers in `sshd_config`, further supporting coexistence of multiple management users.

---
*PR created automatically by Jules for task [15087992780139163209](https://jules.google.com/task/15087992780139163209) started by @Tophicles*