### PR TITLE
Refactor SSH User to Global and Add Windows Support

### DIFF
--- a/add_server.php
+++ b/add_server.php
@@ -67,7 +67,6 @@ if (!empty($data['token'])) {
 // Add OS/SSH fields
 $newServer['os_type'] = $data['os_type'] ?? 'linux';
 if (!empty($data['ssh_port'])) $newServer['ssh_port'] = $data['ssh_port'];
-$newServer['ssh_user'] = $data['ssh_user'] ?? 'mediasvc';
 
 $config['servers'][] = $newServer;
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -94,6 +94,7 @@ function showModalConfirm(message, title = 'Confirm Action') {
 
 let SERVERS = [];
 let SUGGESTED_SSH_USER = 'mediasvc';
+let GLOBAL_SSH_USER = 'mediasvc';
 let ALL_SESSIONS = {};
 let refreshTimer = null;
 let currentView = 'servers'; // 'servers', 'sessions', or 'all'
@@ -110,7 +111,6 @@ function updateServerFormFields() {
     const urlInput = document.getElementById('server-url-input');
     const osSelect = document.getElementById('server-os-select');
     const sshPortGroup = document.getElementById('ssh-port-group');
-    const sshUserGroup = document.getElementById('ssh-user-group');
 
     if (!typeSelect || !apiKeyGroup || !tokenGroup) return;
 
@@ -130,13 +130,11 @@ function updateServerFormFields() {
     }
 
     // OS Logic
-    if (osSelect && sshPortGroup && sshUserGroup) {
+    if (osSelect && sshPortGroup) {
         if (osSelect.value === 'linux') {
             sshPortGroup.style.display = 'flex';
-            sshUserGroup.style.display = 'flex';
         } else {
             sshPortGroup.style.display = 'none';
-            sshUserGroup.style.display = 'none';
         }
     }
 }
@@ -179,9 +177,6 @@ function openServerModal(isEdit = false) {
         btn.textContent = 'Add Server';
         form.reset();
         delete form.dataset.originalName;
-        // Prepopulate SSH user
-        const sshUserInput = form.querySelector('[name="ssh_user"]');
-        if (sshUserInput) sshUserInput.value = SUGGESTED_SSH_USER;
         // Reset visibility for new form
         updateServerFormFields();
     }
@@ -510,6 +505,7 @@ async function loadConfig() {
         return (a.order||0) - (b.order||0);
     });
     SUGGESTED_SSH_USER = config.suggestedSSHUser || 'mediasvc';
+    GLOBAL_SSH_USER = config.ssh_user || 'mediasvc';
     return config.refreshSeconds || 5;
 }
 
@@ -690,6 +686,12 @@ async function openSSHModal() {
     const modal = document.getElementById('ssh-modal');
     modal.classList.add('visible');
 
+    // Load current user
+    const userDisplay = document.getElementById('ssh-global-user');
+    if (userDisplay) {
+        userDisplay.value = GLOBAL_SSH_USER;
+    }
+
     // Load current key
     const keyDisplay = document.getElementById('ssh-public-key');
     keyDisplay.value = 'Loading...';
@@ -773,6 +775,42 @@ if (sshCopyBtn) {
             this.innerText = 'Copied!';
             setTimeout(() => this.innerText = originalText, 2000);
         });
+    });
+}
+
+const sshUserSaveBtn = document.getElementById('ssh-user-save-btn');
+if (sshUserSaveBtn) {
+    sshUserSaveBtn.addEventListener('click', async function() {
+        const userInput = document.getElementById('ssh-global-user');
+        const user = userInput.value.trim();
+        if (!user) {
+            showModalAlert('SSH Username cannot be empty');
+            return;
+        }
+
+        this.disabled = true;
+        this.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Saving...';
+
+        try {
+            const res = await fetch('ssh_manager.php?action=set_ssh_user', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({ user: user })
+            });
+            const data = await res.json();
+
+            if (data.success) {
+                GLOBAL_SSH_USER = user;
+                showModalAlert('Global SSH Username saved successfully!');
+            } else {
+                showModalAlert('Error: ' + (data.error || 'Unknown error'));
+            }
+        } catch (e) {
+            showModalAlert('Failed to save user: ' + e.message);
+        }
+
+        this.disabled = false;
+        this.innerHTML = 'Save User';
     });
 }
 
@@ -968,7 +1006,7 @@ async function openServerSetupModal(serverId, serverName) {
 
             // Linux Command
             const scriptUrl = `${baseUrl}/os_helpers/linux_setup.sh`;
-            const sshUser = server ? (server.ssh_user || 'mediasvc') : 'mediasvc';
+            const sshUser = GLOBAL_SSH_USER || 'mediasvc';
             cmd = `wget -qO- "${scriptUrl}" | sudo bash -s install "${data.key}" "${sshUser}"`;
 
             cmdDisplay.innerText = cmd;
@@ -1000,7 +1038,7 @@ function openSSHConnectedModal(serverId, serverName) {
 
     // Linux Command
     const scriptUrl = `${baseUrl}/os_helpers/linux_setup.sh`;
-    const sshUser = server ? (server.ssh_user || 'mediasvc') : 'mediasvc';
+    const sshUser = GLOBAL_SSH_USER || 'mediasvc';
     cmd = `wget -qO- "${scriptUrl}" | sudo bash -s uninstall "${sshUser}"`;
 
     cmdDisplay.innerText = cmd;
@@ -1846,10 +1884,15 @@ function renderServerGrid() {
 
         // OS Badge Logic
         let osIcon = 'fa-server';
+        let iconType = 'fa-brands';
         if (!server.os_type || server.os_type === 'linux') osIcon = 'fa-linux';
+        else if (server.os_type === 'windows') osIcon = 'fa-windows';
         else if (server.os_type === 'docker') osIcon = 'fa-docker';
         else if (server.os_type === 'macos') osIcon = 'fa-apple';
-        else if (server.os_type === 'other') osIcon = 'fa-server';
+        else {
+            osIcon = 'fa-server';
+            iconType = 'fa-solid';
+        }
 
         // Drag Handle (Always included if admin, CSS controls visibility)
         const dragHandleHtml = IS_ADMIN ? '<div class="drag-handle"><i class="fa-solid fa-bars"></i></div>' : '';
@@ -1867,7 +1910,7 @@ function renderServerGrid() {
                 <div class="status-dot ${isActive ? 'active server-' + esc(server.type) : ''}"></div>
                 ${isActive ? `${sessions.length} playing` : 'Idle'}
             </div>
-            <div class="card-os-badge"><i class="fa-brands ${osIcon}"></i></div>
+            <div class="card-os-badge"><i class="${iconType} ${osIcon}"></i></div>
         `;
 
         // Click to view sessions (only if not clicking drag handle)
@@ -2045,12 +2088,17 @@ function showSessionsView(serverId, serverName, highlightUser = null) {
     // Header OS Icon (Left)
     if (server) {
         let osIcon = 'fa-server';
+        let iconType = 'fa-brands';
         if (!server.os_type || server.os_type === 'linux') osIcon = 'fa-linux';
+        else if (server.os_type === 'windows') osIcon = 'fa-windows';
         else if (server.os_type === 'docker') osIcon = 'fa-docker';
         else if (server.os_type === 'macos') osIcon = 'fa-apple';
-        else if (server.os_type === 'other') osIcon = 'fa-server';
+        else {
+            osIcon = 'fa-server';
+            iconType = 'fa-solid';
+        }
 
-        headerHtml += `<div class="header-os-badge" title="OS: ${esc(server.os_type || 'linux')}"><i class="fa-brands ${osIcon}"></i></div>`;
+        headerHtml += `<div class="header-os-badge" title="OS: ${esc(server.os_type || 'linux')}"><i class="${iconType} ${osIcon}"></i></div>`;
     }
 
     headerHtml += `
@@ -2735,7 +2783,6 @@ function openEditServerModal(serverId) {
 
     form.querySelector('[name="os_type"]').value = server.os_type || 'linux';
     form.querySelector('[name="ssh_port"]').value = server.ssh_port || '22';
-    form.querySelector('[name="ssh_user"]').value = server.ssh_user || 'mediasvc';
 
     // Store server ID for update
     form.dataset.originalName = server.id;
@@ -2817,8 +2864,7 @@ document.getElementById('add-server-form').addEventListener('submit', async e=>{
         apiKey:f.apiKey.value,
         token:f.token.value,
         os_type: f.os_type.value,
-        ssh_port: f.ssh_port.value,
-        ssh_user: f.ssh_user.value
+        ssh_port: f.ssh_port.value
     };
 
     // If editing, include server ID

--- a/get_config.php
+++ b/get_config.php
@@ -28,6 +28,9 @@ if (validateAndMigrateConfig($config)) {
 
 $isAdmin = isAdmin();
 
+require_once 'ssh_helper.php';
+$config['ssh_user'] = getGlobalSSHUser();
+
 // Generate a unique suggested SSH user for this instance
 $config['suggestedSSHUser'] = 'media_' . substr(hash('sha256', getSecretKey()), 0, 6);
 

--- a/index.php
+++ b/index.php
@@ -195,6 +195,12 @@ $isAdmin = isAdmin();
     <h2 style="margin-bottom: 20px;">SSH Key Management</h2>
 
     <div class="ssh-status-box">
+      <label>SSH Username (Global for all Linux servers)</label>
+      <div style="display:flex; gap:8px; margin-bottom: 15px;">
+        <input type="text" id="ssh-global-user" class="btn" style="flex:1; text-align:left; cursor:text; background:rgba(255,255,255,0.05); border:1px solid var(--border);" placeholder="mediasvc">
+        <button class="btn primary" id="ssh-user-save-btn">Save User</button>
+      </div>
+
       <label>Public Key (for authorized_keys)</label>
       <textarea id="ssh-public-key" readonly class="ssh-key-display" placeholder="No key generated yet."></textarea>
       <button class="btn" id="ssh-copy-btn" style="margin-top: 8px;">Copy to Clipboard</button>
@@ -347,6 +353,7 @@ $isAdmin = isAdmin();
                 <label>OS Type</label>
                 <select name="os_type" id="server-os-select">
                     <option value="linux">Linux</option>
+                    <option value="windows">Windows</option>
                     <option value="docker">Docker</option>
                     <option value="macos">macOS</option>
                     <option value="other">Other</option>
@@ -356,11 +363,6 @@ $isAdmin = isAdmin();
             <div class="server-form-group" id="ssh-port-group">
                 <label>SSH Port (Linux Only)</label>
                 <input type="number" name="ssh_port" value="22" placeholder="22">
-            </div>
-
-            <div class="server-form-group" id="ssh-user-group">
-                <label>SSH Username (Linux Only)</label>
-                <input type="text" name="ssh_user" value="mediasvc" placeholder="mediasvc">
             </div>
         </div>
 

--- a/os_helpers/linux_setup.sh
+++ b/os_helpers/linux_setup.sh
@@ -46,12 +46,18 @@ DPKG=$(command -v dpkg)
 # User creation
 ########################################
 create_user() {
+    if [ -z "$USER_NAME" ]; then
+        echo "❌ USER_NAME is not set."
+        exit 1
+    fi
+
     if id "$USER_NAME" &>/dev/null; then
         echo "User '$USER_NAME' already exists."
         return
     fi
 
     echo "Creating user '$USER_NAME'..."
+    # Attempt adduser (Debian/Ubuntu) then fallback to useradd (RHEL/CentOS/Arch)
     adduser --disabled-password --gecos "" "$USER_NAME" 2>/dev/null \
       || useradd -m -s /usr/sbin/nologin "$USER_NAME"
 }
@@ -138,7 +144,7 @@ install_user() {
     generate_sudoers
 
     echo "Locking down SSH..."
-    # Clean up legacy markers and current user markers
+    # Clean up legacy markers and current user markers to avoid duplicates
     sed -i "/# BEGIN MEDIASVC-MULTIDASH/,/# END MEDIASVC-MULTIDASH/d" "$SSHD_CONFIG"
     sed -i "/$MARKER_START/,/$MARKER_END/d" "$SSHD_CONFIG"
 

--- a/proxy.php
+++ b/proxy.php
@@ -55,7 +55,7 @@ if (in_array($action, ['ssh_restart', 'ssh_stop', 'ssh_start', 'ssh_status', 'ss
 
     // Settings
     $port = $server['ssh_port'] ?: 22;
-    $user = $server['ssh_user'] ?: 'mediasvc';
+    $user = getGlobalSSHUser();
 
     // Determine Service Name based on Type and OS
     $service = '';

--- a/ssh_helper.php
+++ b/ssh_helper.php
@@ -5,6 +5,22 @@ require_once 'path_helper.php';
 define('SSH_KEY_DIR', DATA_DIR . 'keys');
 define('SSH_PRIVATE_KEY_PATH', SSH_KEY_DIR . '/id_rsa');
 define('SSH_PUBLIC_KEY_PATH', SSH_PRIVATE_KEY_PATH . '.pub');
+define('SSH_USER_PATH', SSH_KEY_DIR . '/ssh_user.txt');
+
+function getGlobalSSHUser() {
+    if (file_exists(SSH_USER_PATH)) {
+        $user = trim(file_get_contents(SSH_USER_PATH));
+        if (!empty($user)) return $user;
+    }
+    return 'mediasvc';
+}
+
+function setGlobalSSHUser($user) {
+    ensureKeyDir();
+    $user = trim($user);
+    if (empty($user)) return false;
+    return file_put_contents(SSH_USER_PATH, $user) !== false;
+}
 
 function ensureKeyDir() {
     if (!file_exists(SSH_KEY_DIR)) {
@@ -50,6 +66,11 @@ function generateSSHKeyPair() {
 function executeSSHCommand($host, $port, $user, $command, $timeout = 10) {
     if (!file_exists(SSH_PRIVATE_KEY_PATH)) {
         return ['success' => false, 'error' => 'No SSH private key found. Generate one in settings.'];
+    }
+
+    // Use global user if not specified
+    if (empty($user)) {
+        $user = getGlobalSSHUser();
     }
 
     // Construct the SSH command

--- a/ssh_manager.php
+++ b/ssh_manager.php
@@ -23,6 +23,22 @@ if ($action === 'get_public_key') {
     exit;
 }
 
+if ($action === 'get_ssh_user') {
+    echo json_encode(['success' => true, 'user' => getGlobalSSHUser()]);
+    exit;
+}
+
+if ($action === 'set_ssh_user') {
+    $input = json_decode(file_get_contents('php://input'), true);
+    $user = $input['user'] ?? '';
+    if (setGlobalSSHUser($user)) {
+        echo json_encode(['success' => true]);
+    } else {
+        echo json_encode(['success' => false, 'error' => 'Failed to save SSH user']);
+    }
+    exit;
+}
+
 if ($action === 'generate') {
     $input = json_decode(file_get_contents('php://input'), true);
     $agreed = $input['agreed'] ?? false;

--- a/update_server.php
+++ b/update_server.php
@@ -38,7 +38,7 @@ if($serverIndex === null) {
 $existingServer = $servers['servers'][$serverIndex];
 
 // Fields to update if present in $data, otherwise keep existing
-$updatableFields = ['name', 'type', 'url', 'os_type', 'ssh_port', 'ssh_user', 'order', 'enabled', 'ssh_initialized'];
+$updatableFields = ['name', 'type', 'url', 'os_type', 'ssh_port', 'order', 'enabled', 'ssh_initialized'];
 
 foreach ($updatableFields as $field) {
     if (isset($data[$field])) {


### PR DESCRIPTION
This change refactors how SSH users are managed in MultiDash. Instead of each server having its own SSH user, a single global SSH user is now configured in the SSH Key Management modal. This simplifies server setup and ensures consistency across the instance. Additionally, "Windows" has been added as a supported OS type for servers, complete with a dedicated icon in the dashboard.

---
*PR created automatically by Jules for task [6540626691753587408](https://jules.google.com/task/6540626691753587408) started by @Tophicles*