### PR TITLE
Add Global Library Scan Button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -573,9 +573,11 @@ body {
 .search-container {
   margin-bottom: 20px;
   position: relative;
+  display: flex;
+  gap: 10px;
 }
 .search-container input {
-  width: 100%;
+  flex: 1;
   padding: 12px 16px;
   background: rgba(0, 0, 0, 0.2);
   border: 1px solid var(--border);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3218,6 +3218,52 @@ async function scanAllInlineLibraries(btn) {
     showModalAlert(`Triggered scan for ${count} libraries.`);
 }
 
+async function globalScanAllLibraries() {
+    if (!await showModalConfirm('Are you sure you want to scan ALL libraries on ALL servers? This may put high load on your infrastructure.')) return;
+
+    const btn = document.getElementById('global-scan-btn');
+    const originalContent = btn.innerHTML;
+    const originalText = btn.querySelector('.btn-text')?.textContent || 'Scan All';
+
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> <span class="btn-text">Scanning...</span>';
+
+    let successCount = 0;
+    let failCount = 0;
+
+    // Use Promise.all to trigger all scans concurrently for better performance
+    const scanRequests = SERVERS.map(async (server) => {
+        try {
+            const res = await fetch(`library_actions.php?action=scan&server=${encodeURIComponent(server.name)}&library_id=all`);
+            const data = await res.json();
+            if (data.success) {
+                successCount++;
+            } else {
+                console.error(`Scan failed for ${server.name}:`, data.error);
+                failCount++;
+            }
+        } catch (e) {
+            console.error(`Scan request failed for ${server.name}:`, e);
+            failCount++;
+        }
+    });
+
+    await Promise.all(scanRequests);
+
+    btn.innerHTML = `<i class="fa-solid fa-check"></i> <span class="btn-text">Done</span>`;
+
+    setTimeout(() => {
+        btn.disabled = false;
+        btn.innerHTML = `<i class="fa-solid fa-arrows-rotate"></i> <span class="btn-text">${esc(originalText)}</span>`;
+    }, 3000);
+
+    if (successCount > 0) {
+        showModalAlert(`Scan initiated for ${successCount} servers.` + (failCount > 0 ? ` (${failCount} failed)` : ''));
+    } else {
+        showModalAlert('Failed to initiate scan on any server.', 'Scan Error');
+    }
+}
+
 async function fetchServerStats(serverId) {
     const statsEl = document.getElementById('server-stats');
     if (!statsEl) return;
@@ -3601,6 +3647,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initial load of media users to support User Modals from dashboard badges
     fetchMediaUsers();
+
+    // Global Scan All Button
+    const globalScanBtn = document.getElementById('global-scan-btn');
+    if (globalScanBtn) {
+        globalScanBtn.addEventListener('click', globalScanAllLibraries);
+    }
 });
 
 // Donate Modal Logic

--- a/index.php
+++ b/index.php
@@ -234,6 +234,11 @@ $isAdmin = isAdmin();
 <div id="server-view" class="view-container visible">
   <div class="search-container">
     <input type="text" id="server-search" placeholder="Filter servers...">
+    <?php if ($isAdmin): ?>
+    <button class="btn" id="global-scan-btn" title="Scan All Libraries on All Servers">
+        <i class="fa-solid fa-arrows-rotate"></i> <span class="btn-text">Scan All</span>
+    </button>
+    <?php endif; ?>
   </div>
   <div id="server-grid" class="server-grid"></div>
   <div class="user-lists-container">

--- a/library_actions.php
+++ b/library_actions.php
@@ -134,7 +134,58 @@ if ($type === 'plex') {
         exit;
     }
     elseif ($action === 'scan') {
-        if (!$libraryId) {
+        if ($libraryId === 'all') {
+            // Handle global Plex scan by iterating sections
+            $url = rtrim($baseUrl, '/') . '/library/sections';
+
+            $ch = curl_init();
+            curl_setopt($ch, CURLOPT_URL, $url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+            curl_setopt($ch, CURLOPT_TIMEOUT, 15);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, [
+                "X-Plex-Token: $token",
+                "Accept: application/json"
+            ]);
+
+            $res = curl_exec($ch);
+            curl_close($ch);
+
+            $data = json_decode($res, true);
+            $sections = $data['MediaContainer']['Directory'] ?? [];
+
+            if (empty($sections)) {
+                echo json_encode(['error' => 'No libraries found to scan']);
+                exit;
+            }
+
+            $successCount = 0;
+            foreach ($sections as $sec) {
+                $secId = $sec['key'];
+                $scanUrl = rtrim($baseUrl, '/') . "/library/sections/$secId/refresh";
+
+                $chS = curl_init();
+                curl_setopt($chS, CURLOPT_URL, $scanUrl);
+                curl_setopt($chS, CURLOPT_RETURNTRANSFER, true);
+                curl_setopt($chS, CURLOPT_CONNECTTIMEOUT, 2);
+                curl_setopt($chS, CURLOPT_TIMEOUT, 5);
+                curl_setopt($chS, CURLOPT_HTTPHEADER, ["X-Plex-Token: $token"]);
+                curl_exec($chS);
+                $code = curl_getinfo($chS, CURLINFO_HTTP_CODE);
+                curl_close($chS);
+
+                if ($code === 200 || $code === 201) $successCount++;
+            }
+
+            if ($successCount > 0) {
+                $user = getCurrentUser()['username'] ?? 'Unknown';
+                writeLog("Global Library Scan Initiated: Plex server '$serverName' ($successCount libraries) by user '$user'", "INFO");
+                echo json_encode(['success' => true, 'message' => "Scan started for $successCount libraries"]);
+            } else {
+                echo json_encode(['error' => 'Failed to initiate scans for any library']);
+            }
+            exit;
+        } elseif (!$libraryId) {
             echo json_encode(['error' => 'Missing library ID']);
             exit;
         }
@@ -154,7 +205,7 @@ if ($type === 'plex') {
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
 
-        if ($httpCode === 200) {
+        if ($httpCode === 200 || $httpCode === 201) {
             $user = getCurrentUser()['username'] ?? 'Unknown';
             writeLog("Library Scan Initiated: Plex server '$serverName', Library '$libraryName' (ID: $libraryId) by user '$user'", "INFO");
             echo json_encode(['success' => true, 'message' => 'Scan started']);


### PR DESCRIPTION
Added a global "Scan All" button to the main page for administrators. This button triggers a scan of all libraries on all configured servers. For Plex servers, backend logic was added to handle a global scan request by iterating through all sections. Emby and Jellyfin already supported a global scan via their APIs. The UI includes confirmation and state updates (Scanning/Done) for the button.

---
*PR created automatically by Jules for task [15996692572636346321](https://jules.google.com/task/15996692572636346321) started by @Tophicles*