### PR TITLE
feat: add global library scan and remove redundant UI button

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3161,14 +3161,6 @@ async function fetchAndRenderInlineLibraries(serverName) {
             // Header
             html += '<div style="font-size:0.8rem; font-weight:700; color:var(--muted); margin-right:8px; letter-spacing:0.05em;">LIBRARIES</div>';
 
-            // Scan All Button
-            html += `
-                <button class="btn" style="padding:4px 10px; font-size:0.8rem; background:#37474f; border:1px solid var(--border);" onclick="scanAllInlineLibraries(this)" title="Scan All Libraries">
-                    <i class="fa-solid fa-layer-group"></i> Scan All
-                </button>
-                <div style="width:1px; height:20px; background:var(--border); margin:0 4px;"></div>
-            `;
-
             data.libraries.forEach(lib => {
                 const countBadge = lib.count !== undefined ? `<span style="color:var(--muted); font-size:0.75rem;">(${lib.count})</span>` : '';
                 html += `
@@ -3216,6 +3208,38 @@ async function scanAllInlineLibraries(btn) {
     }, 2000);
 
     showModalAlert(`Triggered scan for ${count} libraries.`);
+}
+
+async function globalScanAllLibraries() {
+    if (!await showModalConfirm('Are you sure you want to scan ALL libraries on ALL servers? This may put high load on your infrastructure.')) return;
+
+    let successCount = 0;
+    let failCount = 0;
+
+    // Use Promise.all to trigger all scans concurrently for better performance
+    const scanRequests = SERVERS.map(async (server) => {
+        try {
+            const res = await fetch(`library_actions.php?action=scan&server=${encodeURIComponent(server.name)}&library_id=all`);
+            const data = await res.json();
+            if (data.success) {
+                successCount++;
+            } else {
+                console.error(`Scan failed for ${server.name}:`, data.error);
+                failCount++;
+            }
+        } catch (e) {
+            console.error(`Scan request failed for ${server.name}:`, e);
+            failCount++;
+        }
+    });
+
+    await Promise.all(scanRequests);
+
+    if (successCount > 0) {
+        showModalAlert(`${successCount} servers have been ordered to scan all their libraries.` + (failCount > 0 ? ` (${failCount} failed)` : ''));
+    } else {
+        showModalAlert('Failed to initiate scan on any server.', 'Scan Error');
+    }
 }
 
 async function fetchServerStats(serverId) {
@@ -3601,6 +3625,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initial load of media users to support User Modals from dashboard badges
     fetchMediaUsers();
+
+    // Global Scan All Button
+    const globalScanBtn = document.getElementById('global-scan-menu-btn');
+    if (globalScanBtn) {
+        globalScanBtn.addEventListener('click', () => {
+            globalScanAllLibraries();
+            if (menuDropdown) menuDropdown.classList.remove('visible');
+        });
+    }
 });
 
 // Donate Modal Logic

--- a/index.php
+++ b/index.php
@@ -63,6 +63,9 @@ $isAdmin = isAdmin();
           <div class="menu-item" id="ssh-keys-nav-btn">
             <i class="fa-solid fa-key"></i> <span>SSH Keys</span>
           </div>
+          <div class="menu-item" id="global-scan-menu-btn">
+            <i class="fa-solid fa-arrows-rotate"></i> <span>Global Library Scan</span>
+          </div>
           <div class="menu-item" id="logs-btn" onclick="window.open('view_logs.php', 'SystemLogs')">
             <i class="fa-solid fa-file-lines"></i> <span>System Logs</span>
           </div>

--- a/library_actions.php
+++ b/library_actions.php
@@ -134,7 +134,58 @@ if ($type === 'plex') {
         exit;
     }
     elseif ($action === 'scan') {
-        if (!$libraryId) {
+        if ($libraryId === 'all') {
+            // Handle global Plex scan by iterating sections
+            $url = rtrim($baseUrl, '/') . '/library/sections';
+
+            $ch = curl_init();
+            curl_setopt($ch, CURLOPT_URL, $url);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+            curl_setopt($ch, CURLOPT_TIMEOUT, 15);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, [
+                "X-Plex-Token: $token",
+                "Accept: application/json"
+            ]);
+
+            $res = curl_exec($ch);
+            curl_close($ch);
+
+            $data = json_decode($res, true);
+            $sections = $data['MediaContainer']['Directory'] ?? [];
+
+            if (empty($sections)) {
+                echo json_encode(['error' => 'No libraries found to scan']);
+                exit;
+            }
+
+            $successCount = 0;
+            foreach ($sections as $sec) {
+                $secId = $sec['key'];
+                $scanUrl = rtrim($baseUrl, '/') . "/library/sections/$secId/refresh";
+
+                $chS = curl_init();
+                curl_setopt($chS, CURLOPT_URL, $scanUrl);
+                curl_setopt($chS, CURLOPT_RETURNTRANSFER, true);
+                curl_setopt($chS, CURLOPT_CONNECTTIMEOUT, 2);
+                curl_setopt($chS, CURLOPT_TIMEOUT, 5);
+                curl_setopt($chS, CURLOPT_HTTPHEADER, ["X-Plex-Token: $token"]);
+                curl_exec($chS);
+                $code = curl_getinfo($chS, CURLINFO_HTTP_CODE);
+                curl_close($chS);
+
+                if ($code === 200 || $code === 201) $successCount++;
+            }
+
+            if ($successCount > 0) {
+                $user = getCurrentUser()['username'] ?? 'Unknown';
+                writeLog("Global Library Scan Initiated: Plex server '$serverName' ($successCount libraries) by user '$user'", "INFO");
+                echo json_encode(['success' => true, 'message' => "Scan started for $successCount libraries"]);
+            } else {
+                echo json_encode(['error' => 'Failed to initiate scans for any library']);
+            }
+            exit;
+        } elseif (!$libraryId) {
             echo json_encode(['error' => 'Missing library ID']);
             exit;
         }
@@ -154,7 +205,7 @@ if ($type === 'plex') {
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
 
-        if ($httpCode === 200) {
+        if ($httpCode === 200 || $httpCode === 201) {
             $user = getCurrentUser()['username'] ?? 'Unknown';
             writeLog("Library Scan Initiated: Plex server '$serverName', Library '$libraryName' (ID: $libraryId) by user '$user'", "INFO");
             echo json_encode(['success' => true, 'message' => 'Scan started']);


### PR DESCRIPTION
- Added "Global Library Scan" menu item for administrators in the dropdown menu.
- Implemented `library_id=all` support in `library_actions.php` for Plex, Emby, and Jellyfin.
- Added `globalScanAllLibraries` to `assets/js/main.js` to trigger concurrent scans.
- Removed the redundant "Scan All" button and `scanAllInlineLibraries` function from the sessions view.