### PR TITLE
Add Library Scan Progress Tracking

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2040,3 +2040,64 @@ form button:hover { background:#45a049; }
 .history-list-container::-webkit-scrollbar-thumb:hover {
     background: rgba(255,255,255,0.2);
 }
+
+/* Library Scan Progress Bars */
+.server-scans-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 4px;
+}
+.scan-progress-container {
+    height: 18px;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+.scan-progress-bar {
+    height: 100%;
+    background: var(--accent);
+    transition: width 0.5s ease-in-out;
+    box-shadow: 0 0 10px rgba(76, 175, 80, 0.3);
+}
+.scan-progress-text {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.65rem;
+    font-weight: 800;
+    color: white;
+    text-shadow: 0 1px 2px rgba(0,0,0,0.9);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0 8px;
+    box-sizing: border-box;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+.scan-progress-container.indeterminate .scan-progress-bar {
+    width: 100% !important;
+    background: linear-gradient(90deg, var(--accent), #81c784, var(--accent));
+    background-size: 200% 100%;
+    animation: scan-pulse 2s infinite linear;
+}
+@keyframes scan-pulse {
+    0% { background-position: 200% 0; }
+    100% { background-position: 0 0; }
+}
+
+[data-theme="light"] .scan-progress-container {
+    background: rgba(0, 0, 0, 0.05);
+    border-color: rgba(0, 0, 0, 0.1);
+}
+[data-theme="light"] .scan-progress-text {
+    text-shadow: 0 1px 1px rgba(0,0,0,0.2);
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -96,6 +96,7 @@ let SERVERS = [];
 let SUGGESTED_SSH_USER = 'mediasvc';
 let GLOBAL_SSH_USER = 'mediasvc';
 let ALL_SESSIONS = {};
+let ALL_SCANS = {};
 let refreshTimer = null;
 let currentView = 'servers'; // 'servers', 'sessions', or 'all'
 let selectedServerId = null;
@@ -557,12 +558,16 @@ async function fetchServer(server){
         });
         clearTimeout(timeoutId);
 
-        if (checkSessionExpiry(res)) return [];
+        if (checkSessionExpiry(res)) return { sessions: [], scans: [] };
 
-        if(!res.ok) return [];
+        if(!res.ok) return { sessions: [], scans: [] };
         const data = await res.json();
+
+        let sessions = [];
+        let scans = [];
+
         if(server.type==="emby" || server.type==="jellyfin"){
-            return data.filter(s=>s.NowPlayingItem).map(s=>({
+            sessions = (data.sessions || []).filter(s=>s.NowPlayingItem).map(s=>({
                 server: server.name,
                 user: s.UserName,
                 title: s.NowPlayingItem.Name,
@@ -585,9 +590,15 @@ async function fetchServer(server){
                 device: s.DeviceName||"",
                 client: s.Client||""
             }));
+
+            scans = (data.scans || []).filter(t => t.Status === 'Running' && (t.Key === 'RefreshLibrary' || t.Name.includes('Library'))).map(t => ({
+                id: t.Id,
+                name: t.Name,
+                progress: (t.CurrentProgressPercentage !== undefined && t.CurrentProgressPercentage !== null) ? Math.round(t.CurrentProgressPercentage) : null
+            }));
         } else { // Plex
-            const meta = data.MediaContainer?.Metadata || [];
-            return meta.map(m=>({
+            const meta = data.sessions || [];
+            sessions = meta.map(m=>({
                 server: server.name,
                 user: m.User?.title||"Unknown",
                 title: m.title,
@@ -619,13 +630,20 @@ async function fetchServer(server){
                 device: m.Player?.title||"",
                 client: m.Player?.product||""
             }));
+
+            scans = (data.scans || []).filter(a => a.type === 'library.refresh.items' || a.type === 'library.refresh').map(a => ({
+                id: a.uuid,
+                name: a.subtitle || a.title || 'Library Scan',
+                progress: (a.progress !== undefined && a.progress !== null) ? Math.round(a.progress) : null
+            }));
         }
+        return { sessions, scans };
     } catch(e){
         // Ignore expected AbortError during server restarts/offline
         if (e.name !== 'AbortError') {
             console.error('Server fetch error', e);
         }
-        return [];
+        return { sessions: [], scans: [] };
     }
 }
 
@@ -1795,6 +1813,43 @@ function closeMediaUserModal() {
 }
 
 
+function renderScans(scans) {
+    if (!scans || scans.length === 0) return '';
+
+    return `
+        <div class="server-scans-list">
+            ${scans.map(scan => {
+                const prog = scan.progress !== null ? scan.progress : 100;
+                const isIndeterminate = scan.progress === null;
+                return `
+                    <div class="scan-progress-container ${isIndeterminate ? 'indeterminate' : ''}" title="${esc(scan.name)}: ${isIndeterminate ? 'Scanning...' : prog + '%'}">
+                        <div class="scan-progress-bar" style="width: ${prog}%"></div>
+                        <div class="scan-progress-text">${esc(scan.name)} ${!isIndeterminate ? prog + '%' : ''}</div>
+                    </div>
+                `;
+            }).join('')}
+        </div>
+    `;
+}
+
+function renderServerScans(serverId, serverName) {
+    const container = document.getElementById('server-scans-container');
+    if (!container) return;
+
+    const scans = ALL_SCANS[serverName] || [];
+    if (scans.length === 0) {
+        container.style.display = 'none';
+        container.innerHTML = '';
+        return;
+    }
+
+    container.innerHTML = `
+        <div style="font-size:0.75rem; font-weight:700; color:var(--muted); margin-bottom:8px; text-transform:uppercase; letter-spacing:0.05em;">Active Scans</div>
+        ${renderScans(scans)}
+    `;
+    container.style.display = 'block';
+}
+
 // Render server cards
 function renderServerGrid() {
     // Get search filter
@@ -1910,6 +1965,7 @@ function renderServerGrid() {
                 <div class="status-dot ${isActive ? 'active server-' + esc(server.type) : ''}"></div>
                 ${isActive ? `${sessions.length} playing` : 'Idle'}
             </div>
+            ${renderScans(ALL_SCANS[server.name])}
             <div class="card-os-badge"><i class="${iconType} ${osIcon}"></i></div>
         `;
 
@@ -2200,6 +2256,9 @@ function showSessionsView(serverId, serverName, highlightUser = null) {
         libsEl.style.display = 'none';
         libsEl.innerHTML = '';
     }
+
+    // Render Scans
+    renderServerScans(serverId, serverName);
 
     // Trigger async load of controls if admin and supported OS
     if (IS_ADMIN && server && (!server.os_type || server.os_type === 'linux')) {
@@ -2674,13 +2733,14 @@ async function loadAll(){
     }
 
     const requests = SERVERS.map(async server => {
-        const sessions = await fetchServer(server);
-        ALL_SESSIONS[server.name] = sessions;
+        const result = await fetchServer(server);
+        ALL_SESSIONS[server.name] = result.sessions;
+        ALL_SCANS[server.name] = result.scans;
         loaded++;
         if (progressEl) {
             progressEl.textContent = `Loading servers: ${loaded}/${total}`;
         }
-        return sessions;
+        return result;
     });
     await Promise.all(requests);
 
@@ -2692,6 +2752,7 @@ async function loadAll(){
         const server = SERVERS.find(s => s.id === selectedServerId);
         if (server) {
             renderSessions(server.name);
+            renderServerScans(server.id, server.name);
         }
     } else if (currentView === 'all') {
         renderSessions(null);

--- a/index.php
+++ b/index.php
@@ -261,6 +261,7 @@ $isAdmin = isAdmin();
   <div id="server-title"></div>
   <div id="server-stats" style="text-align:center; color:var(--muted); font-size:0.9rem; margin-bottom:10px; display:none; font-family: monospace;"></div>
   <div id="server-libraries-container" style="margin-bottom:16px; display:none;"></div>
+  <div id="server-scans-container" style="margin-bottom:16px; display:none;"></div>
   <div class="search-container">
     <input type="text" id="session-search" placeholder="Filter sessions...">
   </div>

--- a/proxy.php
+++ b/proxy.php
@@ -279,30 +279,55 @@ if ($server['type'] === 'plex') {
 
         echo json_encode($response);
         exit;
-    } else {
-        $url = rtrim($baseUrl, '/') . '/status/sessions';
     }
 
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $url);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    // Default action: sessions + activities
+    $urlSessions = rtrim($baseUrl, '/') . '/status/sessions';
+    $urlActivities = rtrim($baseUrl, '/') . '/activities';
+    $headers = [
         "X-Plex-Token: $token",
         "Accept: application/json"
-    ]);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+    ];
 
     $startTime = microtime(true);
-    $res = curl_exec($ch);
-    $duration = microtime(true) - $startTime;
 
-    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    $error = curl_error($ch);
-    curl_close($ch);
+    $ch1 = curl_init($urlSessions);
+    curl_setopt($ch1, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch1, CURLOPT_HTTPHEADER, $headers);
+    curl_setopt($ch1, CURLOPT_TIMEOUT, 10);
+
+    $ch2 = curl_init($urlActivities);
+    curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch2, CURLOPT_HTTPHEADER, $headers);
+    curl_setopt($ch2, CURLOPT_TIMEOUT, 10);
+
+    $mh = curl_multi_init();
+    curl_multi_add_handle($mh, $ch1);
+    curl_multi_add_handle($mh, $ch2);
+
+    $active = null;
+    do {
+        $status = curl_multi_exec($mh, $active);
+        if ($active) {
+            if (curl_multi_select($mh) == -1) { usleep(100); }
+        }
+    } while ($active && $status == CURLM_OK);
+
+    $resSessions = curl_multi_getcontent($ch1);
+    $resActivities = curl_multi_getcontent($ch2);
+
+    $httpCode = curl_getinfo($ch1, CURLINFO_HTTP_CODE);
+    $error = curl_error($ch1);
+
+    curl_multi_remove_handle($mh, $ch1);
+    curl_multi_remove_handle($mh, $ch2);
+    curl_multi_close($mh);
+
+    $duration = microtime(true) - $startTime;
 
     // Log slow requests (> 2 seconds)
     if ($duration > 2.0) {
-        writeLog("Slow Plex response from {$server['name']}: " . round($duration, 2) . "s", "WARN");
+        writeLog("Slow Plex response (multi) from {$server['name']}: " . round($duration, 2) . "s", "WARN");
     }
 
     if ($error) {
@@ -312,11 +337,17 @@ if ($server['type'] === 'plex') {
         writeLog("Plex API HTTP $httpCode for {$server['name']}", "ERROR");
     }
 
-    if ($res && $httpCode === 200) {
-        logWatchers($server['name'], 'plex', $res);
+    if ($resSessions && $httpCode === 200) {
+        logWatchers($server['name'], 'plex', $resSessions);
     }
 
-    echo $res ?: json_encode(['MediaContainer'=>['Metadata'=>[]]]);
+    $dataSessions = json_decode($resSessions, true);
+    $dataActivities = json_decode($resActivities, true);
+
+    echo json_encode([
+        'sessions' => $dataSessions['MediaContainer']['Metadata'] ?? [],
+        'scans' => $dataActivities['MediaContainer']['Activity'] ?? []
+    ]);
     exit;
 }
 
@@ -390,31 +421,55 @@ if ($server['type'] === 'emby' || $server['type'] === 'jellyfin') {
 
         echo json_encode($response);
         exit;
-    } else {
-        $url = rtrim($baseUrl, '/') . '/Sessions';
     }
 
+    // Default action: sessions + scheduled tasks
+    $urlSessions = rtrim($baseUrl, '/') . '/Sessions';
+    $urlTasks = rtrim($baseUrl, '/') . '/ScheduledTasks';
     $headers = [
         "X-Emby-Token: $apiKey",
-        "X-MediaBrowser-Token: $apiKey" // Jellyfin compatibility
+        "X-MediaBrowser-Token: $apiKey",
+        "Accept: application/json"
     ];
 
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $url);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
-
     $startTime = microtime(true);
-    $res = curl_exec($ch);
+
+    $ch1 = curl_init($urlSessions);
+    curl_setopt($ch1, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch1, CURLOPT_HTTPHEADER, $headers);
+    curl_setopt($ch1, CURLOPT_TIMEOUT, 10);
+
+    $ch2 = curl_init($urlTasks);
+    curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch2, CURLOPT_HTTPHEADER, $headers);
+    curl_setopt($ch2, CURLOPT_TIMEOUT, 10);
+
+    $mh = curl_multi_init();
+    curl_multi_add_handle($mh, $ch1);
+    curl_multi_add_handle($mh, $ch2);
+
+    $active = null;
+    do {
+        $status = curl_multi_exec($mh, $active);
+        if ($active) {
+            if (curl_multi_select($mh) == -1) { usleep(100); }
+        }
+    } while ($active && $status == CURLM_OK);
+
+    $resSessions = curl_multi_getcontent($ch1);
+    $resTasks = curl_multi_getcontent($ch2);
+
+    $httpCode = curl_getinfo($ch1, CURLINFO_HTTP_CODE);
+    $error = curl_error($ch1);
+
+    curl_multi_remove_handle($mh, $ch1);
+    curl_multi_remove_handle($mh, $ch2);
+    curl_multi_close($mh);
+
     $duration = microtime(true) - $startTime;
 
-    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    $error = curl_error($ch);
-    curl_close($ch);
-
     if ($duration > 2.0) {
-        writeLog("Slow Emby response from {$server['name']}: " . round($duration, 2) . "s", "WARN");
+        writeLog("Slow Emby response (multi) from {$server['name']}: " . round($duration, 2) . "s", "WARN");
     }
 
     if ($error) {
@@ -424,11 +479,17 @@ if ($server['type'] === 'emby' || $server['type'] === 'jellyfin') {
         writeLog("Emby API HTTP $httpCode for {$server['name']}", "ERROR");
     }
 
-    if ($res && $httpCode === 200) {
-        logWatchers($server['name'], 'emby', $res);
+    if ($resSessions && $httpCode === 200) {
+        logWatchers($server['name'], 'emby', $resSessions);
     }
 
-    echo $res ?: json_encode([]);
+    $dataSessions = json_decode($resSessions, true);
+    $dataTasks = json_decode($resTasks, true);
+
+    echo json_encode([
+        'sessions' => $dataSessions ?: [],
+        'scans' => $dataTasks ?: []
+    ]);
     exit;
 }
 


### PR DESCRIPTION
This change implements library scan progress tracking for Plex, Emby, and Jellyfin. 

Key changes:
1. **Backend (`proxy.php`):** Now concurrently fetches session data and active background tasks (scans) from media server APIs. For Plex, it queries `/activities`; for Emby/Jellyfin, it queries `/ScheduledTasks`.
2. **Frontend (`assets/js/main.js`):** Processes the combined response and maintains a global `ALL_SCANS` object. Added helper functions `renderScans` and `renderServerScans` to generate the UI for active scans.
3. **UI/UX:**
    - On the main dashboard, each server card now displays active scans just below the playing status.
    - In the individual server view, a new "ACTIVE SCANS" section appears above the sessions when scans are running.
    - Progress bars include the library name and percentage. If the server doesn't provide a percentage, a full-width pulsing bar is shown instead.
4. **Styling:** New CSS rules in `assets/css/style.css` provide attractive, themed progress bars that work in both light and dark modes.

---
*PR created automatically by Jules for task [12552590095261799882](https://jules.google.com/task/12552590095261799882) started by @Tophicles*