### PR TITLE
Remove Scan All button from server filter area

### DIFF
--- a/index.php
+++ b/index.php
@@ -237,11 +237,6 @@ $isAdmin = isAdmin();
 <div id="server-view" class="view-container visible">
   <div class="search-container">
     <input type="text" id="server-search" placeholder="Filter servers...">
-    <?php if ($isAdmin): ?>
-    <button class="btn" id="global-scan-btn" title="Scan All Libraries on All Servers">
-        <i class="fa-solid fa-arrows-rotate"></i> <span class="btn-text">Scan All</span>
-    </button>
-    <?php endif; ?>
   </div>
   <div id="server-grid" class="server-grid"></div>
   <div class="user-lists-container">


### PR DESCRIPTION
The task was to remove the 'Scan All' button from beside the 'filter servers' input field. 

Key changes:
- Removed the `<button>` with `id="global-scan-btn"` from `index.php`.
- Verified that the "Global Library Scan" option in the menu is preserved.
- Confirmed no orphan JavaScript or CSS specifically targeting this button remained (as it had no active listeners).
- Verified the change visually with a Playwright screenshot.

---
*PR created automatically by Jules for task [10642168273650727346](https://jules.google.com/task/10642168273650727346) started by @Tophicles*