### PR TITLE
Make + Add new server button the same height as server cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -352,7 +352,12 @@ body {
   background: linear-gradient(135deg, #aa00aa, #7b1fa2) !important;
   color: white !important;
 }
-.server-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:16px; }
+.server-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fill,minmax(200px,1fr));
+  gap:16px;
+  align-items: start;
+}
 .server-card {
   background: var(--card);
   backdrop-filter: blur(12px);
@@ -365,9 +370,10 @@ body {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-height: auto;
+  min-height: 130px;
   position: relative;
   box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  box-sizing: border-box;
 }
 .server-card.server-emby {
   background: var(--emby-color);
@@ -458,7 +464,7 @@ body {
 .add-server-card {
     border: 2px dashed rgba(255,255,255,0.2) !important;
     background: transparent !important;
-    min-height: 120px;
+    min-height: 130px;
     justify-content: center;
     align-items: center;
     opacity: 0.6;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2048,6 +2048,9 @@ function renderServerGrid() {
 
         // Add "+ Add Server" card for this type if admin and NOT searching
         if (IS_ADMIN && !query) {
+            const addWrapper = document.createElement('div');
+            addWrapper.className = 'server-card-wrapper';
+
             const addCard = document.createElement('div');
             const typeLabel = type.charAt(0).toUpperCase() + type.slice(1);
             addCard.className = `server-card add-server-card server-${type}`;
@@ -2058,7 +2061,8 @@ function renderServerGrid() {
                 </div>
             `;
             addCard.onclick = () => openServerModal(false, type);
-            container.appendChild(addCard);
+            addWrapper.appendChild(addCard);
+            container.appendChild(addWrapper);
         }
     });
 }


### PR DESCRIPTION
This change ensures that the '+ Add new server' button matches the height of standard server cards on the dashboard. It implements a uniform base height of 130px while allowing individual cards to grow if they contain active scan information, thanks to `align-items: start` on the grid. Structural consistency was also improved by wrapping the 'Add' buttons in the same wrapper class as other server cards.

---
*PR created automatically by Jules for task [3554061774282286834](https://jules.google.com/task/3554061774282286834) started by @Tophicles*