### PR TITLE
Indicate playing or paused state in user view

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1900,10 +1900,16 @@ form button:hover { background:#45a049; }
 .user-status-badge i {
     font-size: 0.6rem;
 }
-.user-status-badge.watching {
+.user-status-badge.watching,
+.user-status-badge.playing {
     background: rgba(76, 175, 80, 0.15);
     color: #81c784;
     border-color: rgba(76, 175, 80, 0.3);
+}
+.user-status-badge.paused {
+    background: rgba(255, 152, 0, 0.15);
+    color: #ffb74d;
+    border-color: rgba(255, 152, 0, 0.3);
 }
 .user-status-badge.idle {
     background: rgba(158, 158, 158, 0.1);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1591,7 +1591,16 @@ function renderUserSearchResults(users) {
             const serverName = u.serverName || 'Unknown Server';
             const serverType = u.serverType || 'emby';
             const sessions = ALL_SESSIONS[serverName] || [];
-            const isWatching = sessions.some(s => s.user === u.name);
+            const userSession = sessions.find(s => s.user === u.name);
+            const isWatching = !!userSession;
+            const isPaused = userSession ? userSession.paused : false;
+
+            let statusClass = 'idle';
+            let statusText = 'Idle';
+            if (isWatching) {
+                statusClass = isPaused ? 'paused' : 'playing';
+                statusText = isPaused ? 'Paused' : 'Playing';
+            }
 
             const serverBadgeClass = `badge server-${esc(serverType)}`;
             let badgeColor = '#4caf50';
@@ -1603,8 +1612,8 @@ function renderUserSearchResults(users) {
                     <span class="${serverBadgeClass}" style="background: ${badgeColor}; color: ${u.serverType === 'plex' ? 'black' : 'white'}; cursor: pointer;" title="Jump to Server">${esc(u.serverName)}</span>
                 </div>
                 <div class="user-search-status">
-                    <span class="user-status-badge ${isWatching ? 'watching' : 'idle'}">
-                        <i class="fa-solid fa-circle"></i> ${isWatching ? 'Watching' : 'Idle'}
+                    <span class="user-status-badge ${statusClass}">
+                        <i class="fa-solid fa-circle"></i> ${statusText}
                     </span>
                 </div>
             `;
@@ -1667,6 +1676,14 @@ function openMediaUserModal(u) {
     const sessions = ALL_SESSIONS[u.serverName] || [];
     const activeSession = sessions.find(s => s.user === u.name);
     const isWatching = !!activeSession;
+    const isPaused = activeSession ? activeSession.paused : false;
+
+    let statusClass = 'idle';
+    let statusText = 'Idle';
+    if (isWatching) {
+        statusClass = isPaused ? 'paused' : 'playing';
+        statusText = isPaused ? 'Paused' : 'Playing';
+    }
 
     let lastSeenStr = 'Never';
     if (u.lastLogin) {
@@ -1682,8 +1699,8 @@ function openMediaUserModal(u) {
                 <h2>${esc(u.name)}</h2>
                 <p>${esc(u.serverName)} (${esc(u.serverType)})</p>
                 <div style="margin-top: 8px;">
-                    <span class="user-status-badge ${isWatching ? 'watching' : 'idle'}">
-                        <i class="fa-solid fa-circle"></i> ${isWatching ? 'Watching' : 'Idle'}
+                    <span class="user-status-badge ${statusClass}">
+                        <i class="fa-solid fa-circle"></i> ${statusText}
                     </span>
                 </div>
             </div>
@@ -1706,7 +1723,7 @@ function openMediaUserModal(u) {
                         <i class="fa-solid fa-external-link-alt"></i> Jump to Server
                     </button>
                 </div>
-                <div class="progress-bar" style="margin-top: 0; background: rgba(255,255,255,0.1);">
+                <div class="progress-bar ${isPaused ? 'paused' : ''}" style="margin-top: 0; background: rgba(255,255,255,0.1);">
                     <div class="progress" style="width: ${activeSession.progress || 0}%;"></div>
                 </div>
             </div>


### PR DESCRIPTION
This change enhances the user view (Media User Modal and User Search Results) to clearly indicate whether a user is currently playing or has paused their media. It aligns the color coding with the server view, using green for playing and orange/yellow for paused states for both status badges and progress bars.

---
*PR created automatically by Jules for task [246571153189779888](https://jules.google.com/task/246571153189779888) started by @Tophicles*