### PR TITLE
Fix Emby/Jellyfin Library Item Counts

### DIFF
--- a/library_actions.php
+++ b/library_actions.php
@@ -257,8 +257,8 @@ if ($type === 'emby' || $type === 'jellyfin') {
             // Emby uses ItemId, Jellyfin uses Id
             $id = $item['ItemId'] ?? $item['Id'] ?? '';
             if ($id) {
-                // Fetch count
-                $countUrl = rtrim($baseUrl, '/') . "/Items?ParentId=$id&Recursive=true&Limit=0";
+                // Fetch count - Filter by primary media types to avoid counting seasons/episodes/trailers
+                $countUrl = rtrim($baseUrl, '/') . "/Items?ParentId=$id&Recursive=true&IncludeItemTypes=Movie,Series,MusicArtist,Audio,Photo,PhotoAlbum,Book,Video&Limit=0";
 
                 $chCount = curl_init();
                 curl_setopt($chCount, CURLOPT_URL, $countUrl);


### PR DESCRIPTION
Fixed an issue where the library item counts for Emby (and Jellyfin) were inflated or more than double the actual numbers shown in the Emby dashboard. This was caused by the recursive query counting nested items like seasons, episodes, and extras. By specifying the `IncludeItemTypes` query parameter, we restrict the counts to primary top-level media types.

---
*PR created automatically by Jules for task [11908487898818006736](https://jules.google.com/task/11908487898818006736) started by @Tophicles*