### PR TITLE
Dynamically filter Emby/Jellyfin item counts by CollectionType

### DIFF
--- a/library_actions.php
+++ b/library_actions.php
@@ -257,8 +257,27 @@ if ($type === 'emby' || $type === 'jellyfin') {
             // Emby uses ItemId, Jellyfin uses Id
             $id = $item['ItemId'] ?? $item['Id'] ?? '';
             if ($id) {
-                // Fetch count
-                $countUrl = rtrim($baseUrl, '/') . "/Items?ParentId=$id&Recursive=true&Limit=0";
+                $collectionType = strtolower($item['CollectionType'] ?? '');
+
+                $includeTypes = 'Movie,Series,MusicArtist,Audio,Photo,PhotoAlbum,Book,Video'; // Fallback
+                if ($collectionType === 'movies') {
+                    $includeTypes = 'Movie';
+                } elseif ($collectionType === 'tvshows') {
+                    $includeTypes = 'Series';
+                } elseif ($collectionType === 'music') {
+                    $includeTypes = 'MusicArtist';
+                } elseif ($collectionType === 'books') {
+                    $includeTypes = 'Book';
+                } elseif ($collectionType === 'photos') {
+                    $includeTypes = 'Photo,PhotoAlbum';
+                } elseif ($collectionType === 'musicvideos') {
+                    $includeTypes = 'MusicVideo';
+                } elseif ($collectionType === 'homevideos') {
+                    $includeTypes = 'Video';
+                }
+
+                // Fetch count - Filter by primary media types to avoid counting seasons/episodes/trailers
+                $countUrl = rtrim($baseUrl, '/') . "/Items?ParentId=$id&Recursive=true&IncludeItemTypes=$includeTypes&Limit=0";
 
                 $chCount = curl_init();
                 curl_setopt($chCount, CURLOPT_URL, $countUrl);


### PR DESCRIPTION
Enhanced the library item counting logic for Emby and Jellyfin by checking the `CollectionType` of each library. The `IncludeItemTypes` parameter in the `/Items` request is now dynamically set (e.g., using `Movie` for movies libraries, `Series` for tvshows libraries). This ensures that the item counts shown in the dashboard match the exact native counts reported by the Emby/Jellyfin server, effectively ignoring irrelevant metadata or misclassified extra items.