### PR TITLE
feat: add media user migration tool to move watch states and favorites

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3242,6 +3242,191 @@ function closeUsersModal() {
     document.getElementById('add-user-form').reset();
 }
 
+/* ================= Migrate User Logic ================= */
+
+let migrateEventSource = null;
+
+function openMigrateUserModal() {
+    document.getElementById('migrate-user-modal').classList.add('visible');
+
+    // Populate Source Servers
+    const sourceSelect = document.getElementById('migrate-source-server');
+    const targetSelect = document.getElementById('migrate-target-server');
+
+    sourceSelect.innerHTML = '<option value="">Select a server...</option>';
+    targetSelect.innerHTML = '<option value="">Select a server...</option>';
+
+    SERVERS.forEach(s => {
+        const option = `<option value="${s.id}">${s.name} (${s.type})</option>`;
+        sourceSelect.innerHTML += option;
+
+        // Target can only be Emby or Jellyfin
+        if (s.type === 'emby' || s.type === 'jellyfin') {
+            targetSelect.innerHTML += option;
+        }
+    });
+
+    document.getElementById('migrate-source-user').innerHTML = '<option value="">Select a user...</option>';
+    document.getElementById('migrate-target-user').innerHTML = '<option value="">Select a user...</option>';
+    document.getElementById('migrate-log-container').style.display = 'none';
+    document.getElementById('migrate-log-output').innerHTML = '';
+}
+
+function closeMigrateUserModal() {
+    document.getElementById('migrate-user-modal').classList.remove('visible');
+    if (migrateEventSource) {
+        migrateEventSource.close();
+        migrateEventSource = null;
+    }
+}
+
+function toggleMigrateUserFields() {
+    const type = document.querySelector('input[name="migrate-user-type"]:checked').value;
+    if (type === 'existing') {
+        document.getElementById('migrate-existing-user-group').style.display = 'flex';
+        document.getElementById('migrate-new-user-group').style.display = 'none';
+    } else {
+        document.getElementById('migrate-existing-user-group').style.display = 'none';
+        document.getElementById('migrate-new-user-group').style.display = 'flex';
+    }
+}
+
+function loadMigrateSourceUsers() {
+    const serverId = document.getElementById('migrate-source-server').value;
+    const userSelect = document.getElementById('migrate-source-user');
+    userSelect.innerHTML = '<option value="">Select a user...</option>';
+
+    if (!serverId) return;
+
+    const users = ALL_MEDIA_USERS.filter(u => String(u.serverId) === String(serverId));
+    users.forEach(u => {
+        userSelect.innerHTML += `<option value="${u.id}">${u.name}</option>`;
+    });
+}
+
+function loadMigrateTargetUsers() {
+    const serverId = document.getElementById('migrate-target-server').value;
+    const userSelect = document.getElementById('migrate-target-user');
+    userSelect.innerHTML = '<option value="">Select a user...</option>';
+
+    if (!serverId) return;
+
+    const users = ALL_MEDIA_USERS.filter(u => String(u.serverId) === String(serverId));
+    users.forEach(u => {
+        userSelect.innerHTML += `<option value="${u.id}">${u.name}</option>`;
+    });
+}
+
+async function startMigration() {
+    const sourceServerId = document.getElementById('migrate-source-server').value;
+    const sourceUserId = document.getElementById('migrate-source-user').value;
+    const targetServerId = document.getElementById('migrate-target-server').value;
+
+    const userType = document.querySelector('input[name="migrate-user-type"]:checked').value;
+    const targetUserId = userType === 'existing' ? document.getElementById('migrate-target-user').value : '';
+    const newUserName = userType === 'new' ? document.getElementById('migrate-new-username').value : '';
+    const newUserPassword = userType === 'new' ? document.getElementById('migrate-new-password').value : '';
+
+    if (!sourceServerId || !sourceUserId || !targetServerId) {
+        showModalAlert("Please select source and target servers and users.");
+        return;
+    }
+
+    if (userType === 'existing' && !targetUserId) {
+        showModalAlert("Please select an existing target user.");
+        return;
+    }
+
+    if (userType === 'new' && !newUserName) {
+        showModalAlert("Please provide a new username.");
+        return;
+    }
+
+    const logContainer = document.getElementById('migrate-log-container');
+    const logOutput = document.getElementById('migrate-log-output');
+    logContainer.style.display = 'block';
+    logOutput.innerHTML = '';
+
+    const startBtn = document.getElementById('start-migrate-btn');
+    startBtn.disabled = true;
+    startBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Working...';
+
+    // We use POST fetch with streaming instead of EventSource so we don't leak passwords in GET URL.
+    const payload = {
+        sourceServerId,
+        sourceUserId,
+        targetServerId,
+        targetUserId,
+        newUserName,
+        newUserPassword
+    };
+
+    try {
+        const response = await fetch('migrate_user.php', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder("utf-8");
+        let buffer = '';
+
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            let lines = buffer.split('\n');
+            buffer = lines.pop(); // Keep the last partial line in the buffer
+
+            for (let line of lines) {
+                if (line.startsWith('data: ')) {
+                    try {
+                        const dataStr = line.substring(6).trim();
+                        if (!dataStr) continue;
+                        const data = JSON.parse(dataStr);
+
+                        const div = document.createElement('div');
+                        div.textContent = data.message;
+
+                        if (data.type === 'error') {
+                            div.style.color = '#ef5350';
+                        } else if (data.type === 'success') {
+                            div.style.color = '#66bb6a';
+                        }
+
+                        logOutput.appendChild(div);
+                        logContainer.scrollTop = logContainer.scrollHeight;
+
+                        if (data.type === 'success' && data.percent >= 100) {
+                            // Only naturally stop if we reached 100% completion
+                        }
+                    } catch (e) {
+                        console.error('Error parsing SSE data:', e, line);
+                    }
+                }
+            }
+        }
+    } catch (err) {
+        const div = document.createElement('div');
+        div.textContent = "Error connecting to migration script: " + err.message;
+        div.style.color = '#ef5350';
+        logOutput.appendChild(div);
+        logContainer.scrollTop = logContainer.scrollHeight;
+    } finally {
+        startBtn.disabled = false;
+        startBtn.innerHTML = 'Start Migration';
+    }
+}
+
+
 async function loadUsersList() {
     try {
         const response = await fetch('manage_users.php');

--- a/index.php
+++ b/index.php
@@ -435,7 +435,12 @@ $isAdmin = isAdmin();
   <div class="modal-content">
     <span class="modal-close" onclick="closeUsersModal()">&times;</span>
     <div id="users-modal-body">
-      <h2 style="margin-bottom: 20px;">MultiDash Users</h2>
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
+        <h2>MultiDash Users</h2>
+        <button class="btn primary" onclick="openMigrateUserModal()">
+          <i class="fa-solid fa-exchange-alt"></i> Migrate Media User
+        </button>
+      </div>
       
       <!-- Add User Form -->
       <div class="user-form-container">
@@ -470,6 +475,72 @@ $isAdmin = isAdmin();
         <h3>Existing Users</h3>
         <div id="users-list"></div>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- Migrate User Modal -->
+<div id="migrate-user-modal" class="modal">
+  <div class="modal-content" style="max-width: 600px;">
+    <span class="modal-close" onclick="closeMigrateUserModal()">&times;</span>
+    <h2 style="margin-bottom: 20px;"><i class="fa-solid fa-exchange-alt"></i> Migrate Media User</h2>
+
+    <div style="background: var(--surface-light); padding: 15px; border-radius: 8px; margin-bottom: 20px;">
+      <div class="server-form-group">
+        <label>Source Server (Plex, Emby, Jellyfin)</label>
+        <select id="migrate-source-server" onchange="loadMigrateSourceUsers()"></select>
+      </div>
+      <div class="server-form-group" style="margin-top: 10px;">
+        <label>Source User</label>
+        <select id="migrate-source-user">
+            <option value="">Select a user...</option>
+        </select>
+      </div>
+    </div>
+
+    <div style="background: var(--surface-light); padding: 15px; border-radius: 8px; margin-bottom: 20px;">
+      <div class="server-form-group">
+        <label>Destination Server (Emby/Jellyfin Only)</label>
+        <select id="migrate-target-server" onchange="loadMigrateTargetUsers()"></select>
+      </div>
+
+      <div style="margin-top: 15px; margin-bottom: 10px;">
+          <label style="display:inline-flex; align-items:center; cursor:pointer; margin-right: 15px;">
+              <input type="radio" name="migrate-user-type" value="existing" checked onchange="toggleMigrateUserFields()">
+              <span style="margin-left:5px;">Map to Existing User</span>
+          </label>
+          <label style="display:inline-flex; align-items:center; cursor:pointer;">
+              <input type="radio" name="migrate-user-type" value="new" onchange="toggleMigrateUserFields()">
+              <span style="margin-left:5px;">Create New User</span>
+          </label>
+      </div>
+
+      <div class="server-form-group" id="migrate-existing-user-group">
+        <label>Target User</label>
+        <select id="migrate-target-user">
+            <option value="">Select a user...</option>
+        </select>
+      </div>
+
+      <div id="migrate-new-user-group" style="display:none; gap: 10px; flex-direction: column;">
+          <div class="server-form-group">
+            <label>New Username</label>
+            <input type="text" id="migrate-new-username" placeholder="e.g. JohnDoe">
+          </div>
+          <div class="server-form-group">
+            <label>Password (Optional)</label>
+            <input type="password" id="migrate-new-password">
+          </div>
+      </div>
+    </div>
+
+    <div class="log-container" id="migrate-log-container" style="display:none; background: #111; color: #0f0; padding: 10px; border-radius: 4px; font-family: monospace; height: 150px; overflow-y: auto; margin-bottom: 20px; border: 1px solid #333; font-size: 0.85rem;">
+        <div id="migrate-log-output"></div>
+    </div>
+
+    <div style="display: flex; justify-content: flex-end; gap: 10px;">
+        <button class="btn" onclick="closeMigrateUserModal()">Cancel</button>
+        <button class="btn primary" id="start-migrate-btn" onclick="startMigration()">Start Migration</button>
     </div>
   </div>
 </div>

--- a/migrate_user.php
+++ b/migrate_user.php
@@ -1,0 +1,408 @@
+<?php
+error_reporting(E_ALL & ~E_DEPRECATED);
+ini_set('display_errors', 0);
+
+require_once 'auth.php';
+require_once 'encryption_helper.php';
+require_once 'logging.php';
+requireLogin();
+
+// Since migration can take a while, allow script to run longer
+set_time_limit(300);
+
+header('Content-Type: text/event-stream');
+header('Cache-Control: no-cache');
+header('Connection: keep-alive');
+
+function sendProgress($message, $type = 'info', $percent = null) {
+    $data = ['message' => $message, 'type' => $type];
+    if ($percent !== null) {
+        $data['percent'] = $percent;
+    }
+    echo "data: " . json_encode($data) . "\n\n";
+    ob_flush();
+    flush();
+}
+
+$input = json_decode(file_get_contents('php://input'), true) ?? [];
+
+$sourceServerId = $input['sourceServerId'] ?? '';
+$sourceUserId = $input['sourceUserId'] ?? '';
+$targetServerId = $input['targetServerId'] ?? '';
+$targetUserId = $input['targetUserId'] ?? ''; // if empty, we create new user
+$newUserName = $input['newUserName'] ?? '';
+$newUserPassword = $input['newUserPassword'] ?? '';
+
+if (!$sourceServerId || !$sourceUserId || !$targetServerId) {
+    sendProgress("Missing required parameters.", "error");
+    exit;
+}
+
+if (!$targetUserId && !$newUserName) {
+    sendProgress("Must provide target user or new user name.", "error");
+    exit;
+}
+
+$serversFile = DB_DIR . 'servers.json';
+if (!file_exists($serversFile)) {
+    sendProgress("Servers configuration not found.", "error");
+    exit;
+}
+
+$config = json_decode(file_get_contents($serversFile), true);
+$servers = $config['servers'] ?? [];
+
+$sourceServer = null;
+$targetServer = null;
+
+foreach ($servers as $s) {
+    if ((string)$s['id'] === (string)$sourceServerId) {
+        $sourceServer = $s;
+    }
+    if ((string)$s['id'] === (string)$targetServerId) {
+        $targetServer = $s;
+    }
+}
+
+if (!$sourceServer || !$targetServer) {
+    sendProgress("Source or target server not found.", "error");
+    exit;
+}
+
+if ($targetServer['type'] === 'plex') {
+    sendProgress("Plex cannot be used as a target server.", "error");
+    exit;
+}
+
+$targetBaseUrl = rtrim($targetServer['url'], '/');
+if (!preg_match('/^https?:\/\//', $targetBaseUrl)) {
+    $targetBaseUrl = 'http://' . $targetBaseUrl;
+}
+$targetApiKey = isset($targetServer['apiKey']) ? decrypt($targetServer['apiKey']) : '';
+
+$sourceBaseUrl = rtrim($sourceServer['url'], '/');
+if (!preg_match('/^https?:\/\//', $sourceBaseUrl)) {
+    $sourceBaseUrl = 'http://' . $sourceBaseUrl;
+}
+$sourceType = $sourceServer['type'];
+$sourceToken = '';
+if ($sourceType === 'plex') {
+    $sourceToken = isset($sourceServer['token']) ? decrypt($sourceServer['token']) : '';
+} else {
+    $sourceToken = isset($sourceServer['apiKey']) ? decrypt($sourceServer['apiKey']) : '';
+}
+
+// 1. Handle User Creation if needed
+if (!$targetUserId && $newUserName) {
+    sendProgress("Creating new user '$newUserName' on target server...", "info");
+
+    $url = "$targetBaseUrl/Users/New";
+    $payload = json_encode(['Name' => $newUserName]);
+
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        "X-Emby-Token: $targetApiKey",
+        "X-MediaBrowser-Token: $targetApiKey",
+        "Content-Type: application/json",
+        "Accept: application/json"
+    ]);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+    $res = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($httpCode === 200 && $res) {
+        $newUser = json_decode($res, true);
+        $targetUserId = $newUser['Id'] ?? '';
+        if (!$targetUserId) {
+            sendProgress("Failed to create user. Response: $res", "error");
+            exit;
+        }
+        sendProgress("User '$newUserName' created successfully (ID: $targetUserId).", "success");
+
+        // Set password if provided
+        if ($newUserPassword) {
+            $urlPw = "$targetBaseUrl/Users/$targetUserId/Password";
+            $payloadPw = json_encode(['CurrentPw' => '', 'NewPw' => $newUserPassword]);
+            $chPw = curl_init($urlPw);
+            curl_setopt($chPw, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($chPw, CURLOPT_POST, true);
+            curl_setopt($chPw, CURLOPT_POSTFIELDS, $payloadPw);
+            curl_setopt($chPw, CURLOPT_HTTPHEADER, [
+                "X-Emby-Token: $targetApiKey",
+                "X-MediaBrowser-Token: $targetApiKey",
+                "Content-Type: application/json",
+                "Accept: application/json"
+            ]);
+            curl_setopt($chPw, CURLOPT_SSL_VERIFYPEER, false);
+            curl_exec($chPw);
+            curl_close($chPw);
+            sendProgress("Password set for new user.", "success");
+        }
+    } else {
+        sendProgress("Failed to create user. HTTP Code: $httpCode", "error");
+        exit;
+    }
+} else {
+    sendProgress("Mapping to existing user ID: $targetUserId on target server...", "info");
+}
+
+// Helper to extract external IDs from Plex item
+function getPlexItemGuids($baseUrl, $token, $ratingKey) {
+    $url = "$baseUrl/library/metadata/$ratingKey";
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ["X-Plex-Token: $token", "Accept: application/json"]);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+    $res = curl_exec($ch);
+    curl_close($ch);
+
+    $guids = [];
+    if ($res) {
+        $data = json_decode($res, true);
+        $metadata = $data['MediaContainer']['Metadata'][0] ?? null;
+        if ($metadata && isset($metadata['Guid'])) {
+            foreach ($metadata['Guid'] as $g) {
+                // e.g. "imdb://tt12345", "tmdb://12345"
+                if (preg_match('/^(imdb|tmdb|tvdb):\/\/(.+)$/', $g['id'], $matches)) {
+                    $guids[$matches[1]] = $matches[2];
+                }
+            }
+        }
+    }
+    return $guids;
+}
+
+// Helper to fetch target items by external IDs (returning all matches)
+function findTargetItemsByGuids($baseUrl, $apiKey, $guids) {
+    if (empty($guids)) return [];
+
+    $queryParts = [];
+    foreach ($guids as $provider => $id) {
+        $queryParts[] = ucfirst($provider) . ".$id";
+    }
+    $queryString = "AnyProviderIdEquals=" . implode(',', $queryParts);
+
+    // We search recursively to find movies, series, episodes
+    $url = "$baseUrl/Items?Recursive=true&$queryString";
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        "X-Emby-Token: $apiKey",
+        "X-MediaBrowser-Token: $apiKey",
+        "Accept: application/json"
+    ]);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+    $res = curl_exec($ch);
+    curl_close($ch);
+
+    $items = [];
+    if ($res) {
+        $data = json_decode($res, true);
+        if (!empty($data['Items'])) {
+            foreach ($data['Items'] as $item) {
+                $items[] = $item['Id'];
+            }
+        }
+    }
+    return $items;
+}
+
+// Helper to update watch state/favorites on target
+function updateTargetItemState($baseUrl, $apiKey, $userId, $itemId, $isFavorite, $isWatched, $lastPlayedDate = null, $resumePositionTicks = 0) {
+    // 1. Favorite
+    if ($isFavorite) {
+        $url = "$baseUrl/Users/$userId/FavoriteItems/$itemId";
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ["X-Emby-Token: $apiKey", "X-MediaBrowser-Token: $apiKey", "Accept: application/json"]);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_exec($ch);
+        curl_close($ch);
+    }
+
+    // 2. Watched State
+    if ($isWatched) {
+        $url = "$baseUrl/Users/$userId/PlayedItems/$itemId";
+        if ($lastPlayedDate) {
+            $url .= "?DatePlayed=" . urlencode($lastPlayedDate);
+        }
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ["X-Emby-Token: $apiKey", "X-MediaBrowser-Token: $apiKey", "Accept: application/json"]);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_exec($ch);
+        curl_close($ch);
+    } elseif ($resumePositionTicks > 0) {
+        // Set resume point
+        $url = "$baseUrl/Users/$userId/PlayingItems/$itemId/Progress?PositionTicks=$resumePositionTicks";
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ["X-Emby-Token: $apiKey", "X-MediaBrowser-Token: $apiKey", "Accept: application/json"]);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_exec($ch);
+        curl_close($ch);
+    }
+}
+
+// 2. Fetch source items (watched/in-progress/favorites)
+sendProgress("Fetching source items...", "info");
+
+$itemsToMigrate = [];
+
+if ($sourceType === 'plex') {
+    // Fetch from Plex
+    $offset = 0;
+    $limit = 1000;
+    $totalFetched = 0;
+    $plexItemsSeen = [];
+
+    while (true) {
+        $url = "$sourceBaseUrl/status/sessions/history/all?accountID=$sourceUserId&sort=viewedAt:desc&container-start=$offset&container-size=$limit";
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ["X-Plex-Token: $sourceToken", "Accept: application/json"]);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        $res = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode !== 200 || !$res) break;
+
+        $data = json_decode($res, true);
+        $metadata = $data['MediaContainer']['Metadata'] ?? [];
+        if (empty($metadata)) break;
+
+        foreach ($metadata as $item) {
+            $ratingKey = $item['ratingKey'];
+            // Plex returns individual watch events. Deduplicate to save API calls
+            if (!isset($plexItemsSeen[$ratingKey])) {
+                $plexItemsSeen[$ratingKey] = true;
+                $itemsToMigrate[] = [
+                    'id' => $ratingKey,
+                    'title' => $item['title'] ?? 'Unknown',
+                    'isWatched' => true,
+                    'isFavorite' => false,
+                    'lastPlayedDate' => isset($item['viewedAt']) ? date('c', (int)$item['viewedAt']) : null,
+                    'resumePositionTicks' => 0
+                ];
+            }
+        }
+
+        $totalFetched += count($metadata);
+        sendProgress("Fetched $totalFetched watch events from Plex...", "info");
+
+        if (count($metadata) < $limit) break;
+        $offset += $limit;
+    }
+
+    // We cannot reliably get Plex user view progress (in-progress) using just the admin token and `accountID`
+    // because `/library/onDeck` ignores `accountID`. It would require switching tokens which is complex.
+    // So we just stick to history.
+
+} else {
+    // Fetch from Emby/Jellyfin
+    // Note: Emby/Jellyfin `Filters=A,B` does a logical AND. We must fetch everything with UserData
+    // and filter locally to ensure we get watched, favorite, or resumable.
+    $url = "$sourceBaseUrl/Users/$sourceUserId/Items?Recursive=true&Fields=UserData,ProviderIds&EnableUserData=true";
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ["X-Emby-Token: $sourceToken", "X-MediaBrowser-Token: $sourceToken", "Accept: application/json"]);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+    $res = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($httpCode === 200 && $res) {
+        $data = json_decode($res, true);
+        $items = $data['Items'] ?? [];
+        foreach ($items as $item) {
+            $userData = $item['UserData'] ?? [];
+            if (empty($userData)) continue;
+
+            $isWatched = $userData['Played'] ?? false;
+            $isFavorite = $userData['IsFavorite'] ?? false;
+            $resumePositionTicks = $userData['PlaybackPositionTicks'] ?? 0;
+
+            if ($isWatched || $isFavorite || $resumePositionTicks > 0) {
+                $itemsToMigrate[] = [
+                    'id' => $item['Id'],
+                    'title' => $item['Name'] ?? 'Unknown',
+                    'isWatched' => $isWatched,
+                    'isFavorite' => $isFavorite,
+                    'lastPlayedDate' => $userData['LastPlayedDate'] ?? null,
+                    'resumePositionTicks' => $resumePositionTicks,
+                    'providerIds' => $item['ProviderIds'] ?? []
+                ];
+            }
+        }
+        sendProgress("Fetched " . count($itemsToMigrate) . " items to migrate from source server.", "info");
+    } else {
+        sendProgress("Failed to fetch items from Emby/Jellyfin source.", "error");
+    }
+}
+
+// 3. Migrate items
+$totalItems = count($itemsToMigrate);
+if ($totalItems === 0) {
+    sendProgress("No items found to migrate.", "success");
+    exit;
+}
+
+sendProgress("Starting migration of $totalItems items...", "info", 0);
+
+$migratedCount = 0;
+$notFoundCount = 0;
+
+foreach ($itemsToMigrate as $i => $item) {
+    $title = $item['title'];
+    $percent = round((($i + 1) / $totalItems) * 100);
+
+    $guids = [];
+    if ($sourceType === 'plex') {
+        $guids = getPlexItemGuids($sourceBaseUrl, $sourceToken, $item['id']);
+    } else {
+        // Translate Emby/Jellyfin ProviderIds
+        foreach ($item['providerIds'] as $provider => $id) {
+            $guids[strtolower($provider)] = $id;
+        }
+    }
+
+    if (empty($guids)) {
+        // No external IDs, can't map
+        $notFoundCount++;
+        sendProgress("Skipping '$title' - No external IDs found.", "error", $percent);
+        continue;
+    }
+
+    $targetItemIds = findTargetItemsByGuids($targetBaseUrl, $targetApiKey, $guids);
+
+    if (!empty($targetItemIds)) {
+        foreach ($targetItemIds as $targetItemId) {
+            updateTargetItemState(
+                $targetBaseUrl,
+                $targetApiKey,
+                $targetUserId,
+                $targetItemId,
+                $item['isFavorite'],
+                $item['isWatched'],
+                $item['lastPlayedDate'],
+                $item['resumePositionTicks']
+            );
+        }
+        $migratedCount++;
+        sendProgress("Migrated '$title' successfully.", "info", $percent);
+    } else {
+        $notFoundCount++;
+        sendProgress("Skipping '$title' - Not found on destination server.", "error", $percent);
+    }
+}
+
+sendProgress("Migration complete! Migrated: $migratedCount, Not Found/Skipped: $notFoundCount.", "success", 100);
+exit;


### PR DESCRIPTION
Added a new dedicated 'Migrate Media User' modal in the dashboard to enable administrators to easily migrate media users between servers. The tool supports migrating a user from Plex, Emby, or Jellyfin to a destination Emby or Jellyfin server by matching IMDb/TMDb external IDs. It migrates completed watch statuses, resume points (for Emby sources), and favorites. Real-time progress is streamed back to the UI using Server-Sent Events (SSE).

* Created `migrate_user.php` to handle the backend extraction, ID mapping, and destination server updates.
* Updated `index.php` and `assets/js/main.js` to provide the migration UI and handle SSE progress tracking.